### PR TITLE
Docker CMD to Remove Instance.properties

### DIFF
--- a/src/Coalesce.Dist/coalesce-karaf-dist/supervisord.conf
+++ b/src/Coalesce.Dist/coalesce-karaf-dist/supervisord.conf
@@ -2,4 +2,4 @@
 nodaemon=true
   
 [program:karaf]
-command=/opt/karaf/bin/karaf
+command=/bin/sh -c "rm -f /opt/karaf/instances/instance.properties && /opt/karaf/bin/karaf clean"


### PR DESCRIPTION
Added cmd to remove the instance.properties to avoid conflicts when restarting.