### PR TITLE
COAL-45 Resolved Removing Children Bug

### DIFF
--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceEntity.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceEntity.java
@@ -692,7 +692,7 @@ public class CoalesceEntity extends CoalesceObjectHistory {
     @JsonIgnore
     public Map<String, CoalesceSection> getSections()
     {
-        return getObjectsAsMap(_entity.getSection());
+        return getObjectsAsMap(CoalesceSection.class);
     }
 
     /**
@@ -702,7 +702,7 @@ public class CoalesceEntity extends CoalesceObjectHistory {
      */
     public List<CoalesceSection> getSectionsAsList()
     {
-        return getObjectsAsList(_entity.getSection());
+        return getObjectsAsList(CoalesceSection.class);
     }
 
     /**

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceLinkageSection.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceLinkageSection.java
@@ -197,7 +197,7 @@ public class CoalesceLinkageSection extends CoalesceObjectHistory {
     @JsonView(Views.Entity.class)
     public List<CoalesceLinkage> getLinkagesAsList()
     {
-        return getObjectsAsList(_entityLinkageSection.getLinkage());
+        return getObjectsAsList(CoalesceLinkage.class);
     }
 
     /**

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceObject.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceObject.java
@@ -86,7 +86,7 @@ public abstract class CoalesceObject implements ICoalesceObject {
     private CoalesceObject _parent;
     private CoalesceObjectType _object;
 
-    private HashMap<String, CoalesceObject> _children = new HashMap<String, CoalesceObject>();
+    private HashMap<String, CoalesceObject> _children = new LinkedHashMap<String, CoalesceObject>();
 
     /*--------------------------------------------------------------------------
     Constructors
@@ -1021,26 +1021,23 @@ public abstract class CoalesceObject implements ICoalesceObject {
     }
 
     /**
-     * @param items
+     * @param clazz
      * @param exclusions status to exclude from the return set.
      * @return a list of CoalesceObjects for the given list of XSD objects
-     * @see #getObjectsAsList(List, ECoalesceObjectStatus...)
+     * @see #getObjectsAsList(Class, ECoalesceObjectStatus...)
      * @deprecated
      */
-    protected <T extends CoalesceObject, Y extends CoalesceObjectType> Map<String, T> getObjectsAsMap(List<Y> items,
+    protected <T extends CoalesceObject, Y extends CoalesceObjectType> Map<String, T> getObjectsAsMap(Class<T> clazz,
                                                                                                       ECoalesceObjectStatus... exclusions)
     {
         List<ECoalesceObjectStatus> statusList = Arrays.asList(exclusions);
-        Map<String, T> results = new HashMap<String, T>();
+        Map<String, T> results = new HashMap<>();
 
-        for (Y item : items)
+        for (CoalesceObject item : getChildCoalesceObjects().values())
         {
-            CoalesceObject childCoalesceObject = getChildCoalesceObject(item.getKey());
-            if (childCoalesceObject != null && !statusList.contains(childCoalesceObject.getStatus()))
+            if (clazz.isAssignableFrom(item.getClass()) && !statusList.contains(item.getStatus()))
             {
-                // You should never get a cast error here because we control
-                // what is inserted into the map.
-                results.put(item.key, (T) childCoalesceObject);
+                results.put(item.getKey(), (T) item);
             }
         }
 
@@ -1048,24 +1045,20 @@ public abstract class CoalesceObject implements ICoalesceObject {
     }
 
     /**
-     * @param items
+     * @param clazz
      * @param exclusions status to exclude from the return set.
      * @return a list of CoalesceObjects for the given list of XSD objects
      */
-    protected <T extends CoalesceObject, Y extends CoalesceObjectType> List<T> getObjectsAsList(List<Y> items,
-                                                                                                ECoalesceObjectStatus... exclusions)
+    protected <T extends CoalesceObject> List<T> getObjectsAsList(Class<T> clazz, ECoalesceObjectStatus... exclusions)
     {
         List<ECoalesceObjectStatus> statusList = Arrays.asList(exclusions);
         List<T> results = new ArrayList<>();
 
-        for (Y item : items)
+        for (CoalesceObject item : getChildCoalesceObjects().values())
         {
-            CoalesceObject childCoalesceObject = getChildCoalesceObject(item.getKey());
-            if (childCoalesceObject != null && !statusList.contains(childCoalesceObject.getStatus()))
+            if (clazz.isAssignableFrom(item.getClass()) && !statusList.contains(item.getStatus()))
             {
-                // You should never get a cast error here because we control
-                // what is inserted into the map.
-                results.add((T) childCoalesceObject);
+                results.add((T) item);
             }
         }
 
@@ -1095,21 +1088,12 @@ public abstract class CoalesceObject implements ICoalesceObject {
     protected void addChildCoalesceObject(CoalesceObject newChild)
     {
         // Add to Parent's Child Collection
-        if (!(_children.containsKey(newChild.getKey())))
-        {
-            _children.put(newChild.getKey(), newChild);
-        }
-
+        _children.put(newChild.getKey(), newChild);
     }
 
     protected void removeChildCoalesceObject(CoalesceObject newChild)
     {
-        // Add to Parent's Child Collection
-        if (!(_children.containsKey(newChild.getKey())))
-        {
-            _children.remove(newChild.getKey());
-        }
-
+        _children.remove(newChild.getKey());
     }
 
     /**

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceRecord.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceRecord.java
@@ -97,7 +97,7 @@ public class CoalesceRecord extends CoalesceObjectHistory {
 
         newRecord.setName(name);
 
-        parent.addChildCoalesceObject(newRecord);
+        //parent.addChildCoalesceObject(newRecord);
 
         return newRecord;
     }
@@ -164,9 +164,9 @@ public class CoalesceRecord extends CoalesceObjectHistory {
      * @return List&lt;CoalesceField&gt; list of {@link CoalesceField} s contained by
      *         this {@link CoalesceRecord} .
      */
-    public List<CoalesceField<?>> getFields()
+    public List<CoalesceField> getFields()
     {
-        return getObjectsAsList(_entityRecord.getField());
+        return getObjectsAsList(CoalesceField.class);
     }
 
     /**

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceRecordset.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceRecordset.java
@@ -201,7 +201,7 @@ public class CoalesceRecordset extends CoalesceObjectHistory implements ICoalesc
     @JsonView(Views.Template.class)
     public List<CoalesceFieldDefinition> getFieldDefinitions()
     {
-        return getObjectsAsList(_entityRecordset.getFielddefinition(),
+        return getObjectsAsList(CoalesceFieldDefinition.class,
                                 ECoalesceObjectStatus.DELETED,
                                 ECoalesceObjectStatus.UNKNOWN);
     }
@@ -213,22 +213,7 @@ public class CoalesceRecordset extends CoalesceObjectHistory implements ICoalesc
     @JsonView(Views.Entity.class)
     public List<CoalesceRecord> getAllRecords()
     {
-        List<CoalesceRecord> results = new ArrayList<CoalesceRecord>();
-
-        for (Record record : _entityRecordset.getRecord())
-        {
-            for (CoalesceObject xdo : getChildCoalesceObjects().values())
-            {
-                if (xdo instanceof CoalesceRecord && xdo.getKey().equalsIgnoreCase(record.getKey()))
-                {
-                    results.add((CoalesceRecord) xdo);
-                    break;
-                }
-            }
-
-        }
-
-        return results;
+        return getObjectsAsList(CoalesceRecord.class);
     }
 
     /**
@@ -237,7 +222,7 @@ public class CoalesceRecordset extends CoalesceObjectHistory implements ICoalesc
     @JsonIgnore
     public List<CoalesceRecord> getRecords()
     {
-        return getObjectsAsList(_entityRecordset.getRecord(), ECoalesceObjectStatus.DELETED, ECoalesceObjectStatus.UNKNOWN);
+        return getObjectsAsList(CoalesceRecord.class, ECoalesceObjectStatus.DELETED, ECoalesceObjectStatus.UNKNOWN);
     }
 
     @Override

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceSection.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceSection.java
@@ -302,7 +302,7 @@ public class CoalesceSection extends CoalesceObjectHistory {
     @JsonIgnore
     public Map<String, CoalesceRecordset> getRecordsets()
     {
-        return getObjectsAsMap(_entitySection.getRecordset(), ECoalesceObjectStatus.DELETED);
+        return getObjectsAsMap(CoalesceRecordset.class, ECoalesceObjectStatus.DELETED);
     }
 
     /**
@@ -313,7 +313,7 @@ public class CoalesceSection extends CoalesceObjectHistory {
      */
     public List<CoalesceRecordset> getRecordsetsAsList()
     {
-        return getObjectsAsList(_entitySection.getRecordset(), ECoalesceObjectStatus.DELETED);
+        return getObjectsAsList(CoalesceRecordset.class, ECoalesceObjectStatus.DELETED);
     }
 
     /**
@@ -358,7 +358,7 @@ public class CoalesceSection extends CoalesceObjectHistory {
     @JsonIgnore
     public Map<String, CoalesceSection> getSections()
     {
-        return getObjectsAsMap(_entitySection.getSection(), ECoalesceObjectStatus.DELETED);
+        return getObjectsAsMap(CoalesceSection.class, ECoalesceObjectStatus.DELETED);
     }
 
     /**
@@ -368,7 +368,7 @@ public class CoalesceSection extends CoalesceObjectHistory {
      */
     public List<CoalesceSection> getSectionsAsList()
     {
-        return getObjectsAsList(_entitySection.getSection(), ECoalesceObjectStatus.DELETED);
+        return getObjectsAsList(CoalesceSection.class, ECoalesceObjectStatus.DELETED);
     }
 
     // -----------------------------------------------------------------------//
@@ -413,10 +413,9 @@ public class CoalesceSection extends CoalesceObjectHistory {
     }
 
     /**
-     * @return a list of {@link Section} that belong to this
-     * {@link CoalesceSection}.
+     * @return a list of {@link Section} that belong to this {@link CoalesceSection}.
      */
-    protected List<Section> getSectionSections()
+    private List<Section> getSectionSections()
     {
         return _entitySection.getSection();
     }

--- a/src/Coalesce/src/test/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceRecordTest.java
+++ b/src/Coalesce/src/test/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceRecordTest.java
@@ -231,7 +231,7 @@ public class CoalesceRecordTest {
     {
         CoalesceRecord record = getMissionRecord();
 
-        List<CoalesceField<?>> fields = record.getFields();
+        List<CoalesceField> fields = record.getFields();
 
         assertEquals(17, fields.size());
 
@@ -239,7 +239,7 @@ public class CoalesceRecordTest {
         boolean middleFound = false;
         boolean lastFound = false;
 
-        for (CoalesceField<?> field : fields)
+        for (CoalesceField field : fields)
         {
             switch (field.getKey())
             {


### PR DESCRIPTION
Resolved bug with removing children objects and switched the children map to be a linked hashmap to preserve order in which added so there is no longer a need for the double loop when getting children as a list.