### PR TITLE
OEBDP-117 Template Key Inconsistency

### DIFF
--- a/src/Coalesce.Services/Search/service-data-jaxrs/src/main/java/com/incadencecorp/coalesce/services/search/service/data/jaxrs/ITemplateDataControllerJaxRS.java
+++ b/src/Coalesce.Services/Search/service-data-jaxrs/src/main/java/com/incadencecorp/coalesce/services/search/service/data/jaxrs/ITemplateDataControllerJaxRS.java
@@ -38,6 +38,7 @@ public interface ITemplateDataControllerJaxRS {
 
     @GET
     @Path("/{name}/{source}/{version}{ext:(/json)?}")
+    @JsonView(Views.Template.class)
     @Produces(MediaType.APPLICATION_JSON)
     CoalesceEntity getTemplate(@PathParam("name") String name, @PathParam("source") String source, @PathParam("version") String version) throws RemoteException;
 


### PR DESCRIPTION
Resolved issue where keys were being returned using the name/source/version endpoint by adding the missing JAXRS annotation. 