### PR TITLE
Delete Operation

### DIFF
--- a/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/drivers/IntervalDriverImpl.java
+++ b/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/drivers/IntervalDriverImpl.java
@@ -142,7 +142,7 @@ public class IntervalDriverImpl extends AbstractDriver {
         // Interval Configured?
         if (parameters.containsKey(SynchronizerParameters.PARAM_DRIVER_INTERVAL))
         {
-            interval = Integer.valueOf(parameters.get(SynchronizerParameters.PARAM_DRIVER_INTERVAL));
+            interval = Integer.parseInt(parameters.get(SynchronizerParameters.PARAM_DRIVER_INTERVAL));
 
             if (interval < 1)
             {
@@ -153,7 +153,7 @@ public class IntervalDriverImpl extends AbstractDriver {
         // Number of Threads Configured?
         if (parameters.containsKey(SynchronizerParameters.PARAM_DRIVER_MAX_THREADS))
         {
-            threads = Integer.valueOf(parameters.get(SynchronizerParameters.PARAM_DRIVER_MAX_THREADS));
+            threads = Integer.parseInt(parameters.get(SynchronizerParameters.PARAM_DRIVER_MAX_THREADS));
 
             if (threads < 1)
             {

--- a/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/operations/DeleteOperationImpl.java
+++ b/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/operations/DeleteOperationImpl.java
@@ -1,0 +1,69 @@
+/*-----------------------------------------------------------------------------'
+ Copyright 2018 - InCadence Strategic Solutions Inc., All Rights Reserved
+
+ Notwithstanding any contractor copyright notice, the Government has Unlimited
+ Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ of this work other than as specifically authorized by these DFARS Clauses may
+ violate Government rights in this work.
+
+ DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ Unlimited Rights. The Government has the right to use, modify, reproduce,
+ perform, display, release or disclose this computer software and to have or
+ authorize others to do so.
+
+ Distribution Statement D. Distribution authorized to the Department of
+ Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ -----------------------------------------------------------------------------*/
+
+package com.incadencecorp.coalesce.synchronizer.service.operations;
+
+import com.incadencecorp.coalesce.common.exceptions.CoalescePersistorException;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.synchronizer.api.common.AbstractOperation;
+import com.incadencecorp.coalesce.synchronizer.api.common.AbstractOperationTask;
+
+import javax.sql.rowset.CachedRowSet;
+import java.util.Map;
+
+/**
+ * This implementation can either mark entities returned by the scanner as deleted or physically delete them from the database.
+ *
+ * @author Derek Clemenzi
+ */
+public class DeleteOperationImpl extends AbstractOperation<AbstractOperationTask> {
+
+    /**
+     * (Boolean) If true then the entities are only marked as deleted; otherwise they are physically deleted.
+     */
+    public static final String PARAM_MARK_AS_DELETED = DeleteOperationImpl.class.getName() + ".markOnly";
+
+    private boolean allowRemoval = false;
+
+    @Override
+    public void setProperties(Map<String, String> params)
+    {
+        super.setProperties(params);
+
+        allowRemoval = Boolean.parseBoolean(parameters.getOrDefault(PARAM_MARK_AS_DELETED, "false"));
+    }
+
+    @Override
+    protected AbstractOperationTask createTask()
+    {
+        return new AbstractOperationTask() {
+
+            @Override
+            protected Boolean doWork(String[] keys, CachedRowSet rowset) throws CoalescePersistorException
+            {
+                CoalesceEntity[] entities = target.getEntity(keys);
+
+                for (CoalesceEntity entity : entities)
+                {
+                    entity.markAsDeleted();
+                }
+
+                return target.saveEntity(allowRemoval, entities);
+            }
+        };
+    }
+}

--- a/src/Coalesce.Synchronizer/service/src/test/java/com/incadencecorp/coalesce/synchronizer/service/tests/DeleteOperationTest.java
+++ b/src/Coalesce.Synchronizer/service/src/test/java/com/incadencecorp/coalesce/synchronizer/service/tests/DeleteOperationTest.java
@@ -1,0 +1,92 @@
+/*-----------------------------------------------------------------------------'
+ Copyright 2018 - InCadence Strategic Solutions Inc., All Rights Reserved
+
+ Notwithstanding any contractor copyright notice, the Government has Unlimited
+ Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ of this work other than as specifically authorized by these DFARS Clauses may
+ violate Government rights in this work.
+
+ DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ Unlimited Rights. The Government has the right to use, modify, reproduce,
+ perform, display, release or disclose this computer software and to have or
+ authorize others to do so.
+
+ Distribution Statement D. Distribution authorized to the Department of
+ Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ -----------------------------------------------------------------------------*/
+
+package com.incadencecorp.coalesce.synchronizer.service.tests;
+
+import com.incadencecorp.coalesce.api.IExceptionHandler;
+import com.incadencecorp.coalesce.common.helpers.JodaDateTimeHelper;
+import com.incadencecorp.coalesce.framework.CoalesceExecutorServiceImpl;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.framework.datamodel.ECoalesceObjectStatus;
+import com.incadencecorp.coalesce.framework.persistance.derby.DerbyPersistor;
+import com.incadencecorp.coalesce.handlers.LoggerExceptionHandlerImpl;
+import com.incadencecorp.coalesce.synchronizer.api.IPersistorOperation;
+import com.incadencecorp.coalesce.synchronizer.api.IPersistorScan;
+import com.incadencecorp.coalesce.synchronizer.api.common.SynchronizerParameters;
+import com.incadencecorp.coalesce.synchronizer.service.operations.DeleteOperationImpl;
+import com.incadencecorp.coalesce.synchronizer.service.scanners.AfterLastModifiedScanImpl2;
+import org.junit.Assert;
+import org.junit.Test;
+
+import javax.sql.rowset.CachedRowSet;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * These test ensure proper behaviour of the {@link com.incadencecorp.coalesce.synchronizer.service.operations.DeleteOperationImpl}
+ *
+ * @author Derek Clemenzi
+ */
+public class DeleteOperationTest {
+
+    @Test
+    public void testMarkAsDeleted() throws Exception
+    {
+        CoalesceEntity entity1 = new CoalesceEntity();
+        entity1.initialize();
+
+        CoalesceEntity entity2 = new CoalesceEntity();
+        entity2.initialize();
+
+        Map<String, String> params = new HashMap<>();
+        params.put(SynchronizerParameters.PARAM_SCANNER_LAST_SUCCESS,
+                   JodaDateTimeHelper.toXmlDateTimeUTC(JodaDateTimeHelper.nowInUtc().minusDays(2)));
+        params.put(DeleteOperationImpl.PARAM_MARK_AS_DELETED, "false");
+
+        DerbyPersistor derby = new DerbyPersistor();
+
+        derby.saveEntity(false, entity1, entity2);
+
+        IPersistorScan scan = new AfterLastModifiedScanImpl2();
+        scan.setSource(derby);
+        scan.setProperties(params);
+
+        IPersistorOperation operation = new DeleteOperationImpl();
+        operation.setSource(derby);
+        operation.setTarget(derby);
+        operation.setProperties(params);
+
+        Assert.assertEquals(ECoalesceObjectStatus.ACTIVE, derby.getEntity(entity1.getKey())[0].getStatus());
+        Assert.assertEquals(ECoalesceObjectStatus.ACTIVE, derby.getEntity(entity2.getKey())[0].getStatus());
+
+        CoalesceExecutorServiceImpl service = new CoalesceExecutorServiceImpl();
+
+        CachedRowSet rowset = scan.scan();
+        operation.execute(service, rowset);
+
+        Assert.assertEquals(ECoalesceObjectStatus.DELETED, derby.getEntity(entity1.getKey())[0].getStatus());
+        Assert.assertEquals(ECoalesceObjectStatus.DELETED, derby.getEntity(entity2.getKey())[0].getStatus());
+
+        operation.setProperties(Collections.singletonMap(DeleteOperationImpl.PARAM_MARK_AS_DELETED, "true"));
+
+        operation.execute(service, rowset);
+
+        Assert.assertEquals(0, derby.getEntity(entity1.getKey()).length);
+        Assert.assertEquals(0, derby.getEntity(entity2.getKey()).length);
+    }
+}

--- a/src/Coalesce.Synchronizer/service/src/test/java/com/incadencecorp/coalesce/synchronizer/service/tests/SynchronizerTest.java
+++ b/src/Coalesce.Synchronizer/service/src/test/java/com/incadencecorp/coalesce/synchronizer/service/tests/SynchronizerTest.java
@@ -266,7 +266,7 @@ public class SynchronizerTest {
         Assert.assertTrue(CoalescePropertyFactory.getColumnName(CoalescePropertyFactory.getSource()).equalsIgnoreCase(metadata.getColumnLabel(4)));
     }
 
-    private class MockOperation extends AbstractOperation<AbstractOperationTask> {
+    private static class MockOperation extends AbstractOperation<AbstractOperationTask> {
 
         private Set<String> columns = new HashSet<>();
 

--- a/src/Coalesce.Synchronizer/service/src/test/resources/log4j.properties
+++ b/src/Coalesce.Synchronizer/service/src/test/resources/log4j.properties
@@ -1,8 +1,8 @@
 log4j.rootLogger=WARN, STDOUT
 log4j.logger.deng=WARN
 
-log4j.category.com.incadencecorp.coalesce=DEBUG
-log4j.category.com.incadencecorp.coalesce.framework.persistance.CoalesceDataConnectorBase=TRACE
+log4j.category.com.incadencecorp.coalesce=WARN
+log4j.category.com.incadencecorp.coalesce.framework.persistance.CoalesceDataConnectorBase=WARN
 log4j.category.com.incadencecorp.coalesce.synchronizer=TRACE
 log4j.category.com.incadencecorp.coalesce.synchronizer.service.operations=TRACE
 log4j.category.com.incadencecorp.coalesce.synchronizer.service.drivers=TRACE


### PR DESCRIPTION
Implemented an operation that allows for the marking as deleted or physically deleting the entities across multiple databases to clean up production instances. 

Also resolved findbug issues within the module that this operation was created.