### PR TITLE
OEBDP-183 Resolved issue with legacy indexes

### DIFF
--- a/src/Coalesce.Framework.Persister.Elasticsearch/src/main/java/com/incadencecorp/coalesce/framework/persistance/elasticsearch/ElasticSearchQueryRewriter.java
+++ b/src/Coalesce.Framework.Persister.Elasticsearch/src/main/java/com/incadencecorp/coalesce/framework/persistance/elasticsearch/ElasticSearchQueryRewriter.java
@@ -42,7 +42,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Walks through a Filter, re-writing any property names removing the tablename from the property along with the /
@@ -51,6 +50,7 @@ class ElasticSearchQueryRewriter extends DuplicatingFilterVisitor {
 
     private final Set<String> features = new HashSet<>();
     private final ICoalesceNormalizer normalizer;
+    private final Set<String> keywords = new HashSet<>();
 
     /**
      * Standard java logger
@@ -67,6 +67,11 @@ class ElasticSearchQueryRewriter extends DuplicatingFilterVisitor {
         super(CommonFactoryFinder.getFilterFactory2());
 
         this.normalizer = normalizer;
+    }
+
+    public void setKeywords(Set<String> keywords)
+    {
+        this.keywords.addAll(keywords);
     }
 
     @Override
@@ -116,8 +121,7 @@ class ElasticSearchQueryRewriter extends DuplicatingFilterVisitor {
 
         LOGGER.trace("({}): ({})", property, type);
 
-        return (type == ECoalesceFieldDataTypes.STRING_TYPE) && !(property.startsWith("coalesceentity")
-                || property.startsWith("coalescelinkage"));
+        return (type == ECoalesceFieldDataTypes.STRING_TYPE) && !keywords.contains(property);
     }
 
     @Override

--- a/src/Coalesce.Search/src/test/java/com/incadencecorp/coalesce/search/AbstractSearchTest.java
+++ b/src/Coalesce.Search/src/test/java/com/incadencecorp/coalesce/search/AbstractSearchTest.java
@@ -1412,7 +1412,7 @@ public abstract class AbstractSearchTest<T extends ICoalescePersistor & ICoalesc
     {
         TestEntity entity = new TestEntity();
         entity.initialize();
-        entity.setEntityId("hello");
+        entity.setEntityId(UUID.randomUUID().toString());
         entity.setEntityIdType("world");
 
         TestRecord record = entity.addRecord1();
@@ -1422,13 +1422,14 @@ public abstract class AbstractSearchTest<T extends ICoalescePersistor & ICoalesc
         framework.setAuthoritativePersistor(createPersister());
         framework.saveCoalesceEntity(entity);
 
-        Assert.assertEquals(entity.getKey(), framework.findEntityId("hello"));
-        Assert.assertEquals(entity.getKey(), framework.findEntityId("hello", TestEntity.NAME));
-        Assert.assertEquals(null, framework.findEntityId("hello", "UNKNOWN"));
+        Assert.assertEquals(entity.getKey(), framework.findEntityId(entity.getEntityId()));
+        Assert.assertEquals(entity.getKey(), framework.findEntityId(entity.getEntityId(), TestEntity.NAME));
+        Assert.assertEquals(null, framework.findEntityId(entity.getEntityId(), "UNKNOWN"));
+        Assert.assertEquals(entity.getKey(), framework.find(CoalescePropertyFactory.getEntityKey(entity.getKey())));
 
-        Assert.assertEquals(entity.getKey(),
-                            framework.find(FF.equals(CoalescePropertyFactory.getFieldProperty(record.getStringField()),
-                                                     FF.literal(record.getStringField().getValue()))));
+        entity.markAsDeleted();
+
+        framework.saveCoalesceEntity(true, entity);
 
     }
 


### PR DESCRIPTION
Modified unit test to use a UUID for the entityid to avoid potential conflicts with existing entities.

Modified the Elastic persister to queries the core indexes to determine which fields are indexed as keywords to support legacy indexes.