### PR TITLE
Consistent Use of StartIndex

### DIFF
--- a/src/Coalesce.Framework.Persistance/derby/persister/src/main/java/com/incadencecorp/coalesce/framework/persistance/derby/DerbyCoalescePreparedFilter.java
+++ b/src/Coalesce.Framework.Persistance/derby/persister/src/main/java/com/incadencecorp/coalesce/framework/persistance/derby/DerbyCoalescePreparedFilter.java
@@ -20,7 +20,6 @@ import com.incadencecorp.coalesce.common.helpers.StringHelper;
 import com.incadencecorp.coalesce.framework.EnumerationProviderUtil;
 import com.incadencecorp.coalesce.framework.datamodel.ECoalesceFieldDataTypes;
 import com.incadencecorp.coalesce.framework.persistance.postgres.CoalesceIndexInfo;
-import com.incadencecorp.coalesce.framework.persistance.postgres.PostGreSQLSettings;
 import com.incadencecorp.coalesce.framework.persistance.postgres.QueryHelper;
 import com.incadencecorp.coalesce.framework.util.CoalesceTemplateUtil;
 import com.incadencecorp.coalesce.search.api.EFilterEnumerationModes;
@@ -106,7 +105,7 @@ public class DerbyCoalescePreparedFilter extends PostgisPSFilterToSql implements
     private final List<String> enumList = new ArrayList<String>();
     private FilterFactory factory;
 
-    private int pageNumber;
+    private int offset;
     private int pageSize;
     private Capabilities capability;
 
@@ -134,13 +133,13 @@ public class DerbyCoalescePreparedFilter extends PostgisPSFilterToSql implements
 
     /**
      * @param schema
-     * @param pageNumber
+     * @param offset
      * @param pageSize
      * @param includeDeleted
      * @param dialect
      */
     public DerbyCoalescePreparedFilter(String schema,
-                                       int pageNumber,
+                                       int offset,
                                        int pageSize,
                                        boolean includeDeleted,
                                        PostGISPSDialect dialect)
@@ -152,7 +151,7 @@ public class DerbyCoalescePreparedFilter extends PostgisPSFilterToSql implements
         currentSRID = SSRID;
         SRIDs.add(currentSRID);
 
-        setPageNumber(pageNumber);
+        setOffset(offset);
         setPageSize(pageSize);
 
         capability = createCapabilities();
@@ -930,15 +929,9 @@ public class DerbyCoalescePreparedFilter extends PostgisPSFilterToSql implements
      *
      * @param value
      */
-    public void setPageNumber(int value)
+    public void setOffset(int value)
     {
-
-        if (value < 1)
-        {
-            value = 1;
-        }
-
-        pageNumber = value;
+        offset = value < 0 ? 0 : value;
     }
 
     /**
@@ -1060,16 +1053,16 @@ public class DerbyCoalescePreparedFilter extends PostgisPSFilterToSql implements
     }
 
     /**
-     * @return the filtering portion of the SQL
+     * @return the offset portion of the SQL
      */
-    public String getLimit()
+    public String getOffsetClause()
     {
 
         String limit = "";
 
-        if (pageSize > 0)
+        if (offset > 0)
         {
-            limit = String.format("LIMIT %s OFFSET %s", pageSize, (pageNumber - 1) * pageSize);
+            limit = String.format(" OFFSET %s ROWS", offset);
         }
 
         return limit;

--- a/src/Coalesce.Framework.Persistance/derby/persister/src/main/java/com/incadencecorp/coalesce/framework/persistance/derby/DerbyPersistor.java
+++ b/src/Coalesce.Framework.Persistance/derby/persister/src/main/java/com/incadencecorp/coalesce/framework/persistance/derby/DerbyPersistor.java
@@ -989,7 +989,7 @@ public class DerbyPersistor extends CoalescePersistorBase implements ICoalesceSe
     {
         if (query.getStartIndex() == null)
         {
-            query.setStartIndex(1);
+            query.setStartIndex(0);
         }
 
         SearchResults results = new SearchResults();
@@ -1000,7 +1000,7 @@ public class DerbyPersistor extends CoalescePersistorBase implements ICoalesceSe
         {
             // Create SQL Query
             DerbyCoalescePreparedFilter preparedFilter = new DerbyCoalescePreparedFilter(_schema);
-            preparedFilter.setPageNumber(query.getStartIndex());
+            preparedFilter.setOffset(query.getStartIndex());
             preparedFilter.setPageSize(query.getMaxFeatures());
             preparedFilter.setSortBy(query.getSortBy());
             preparedFilter.setPropertNames(query.getPropertyNames());
@@ -1020,17 +1020,18 @@ public class DerbyPersistor extends CoalescePersistorBase implements ICoalesceSe
                                                                          this.getSchema(),
                                                                          "memory"))
             {
-                String sql = String.format("SELECT DISTINCT %s FROM %s %s %s",
+                String sql = String.format("SELECT DISTINCT %s FROM %s %s %s %s",
                                            preparedFilter.getColumns(),
                                            preparedFilter.getFrom(),
                                            where,
-                                           preparedFilter.getSorting());
+                                           preparedFilter.getSorting(),
+                                           preparedFilter.getOffsetClause());
 
                 LOGGER.debug("Executing: {}", sql);
 
                 // Get Hits
                 CachedRowSet hits = RowSetProvider.newFactory().createCachedRowSet();
-                hits.populate(conn.executeQuery(sql, params));
+                hits.populate(conn.executeQuery(sql, query.getMaxFeatures(), params));
 
                 hits.last();
                 int numberOfHits = hits.getRow();

--- a/src/Coalesce.Framework.Persister.Accumulo/src/test/java/com/incadencecorp/coalesce/framework/persistance/accumulo/Accumulo2SearchTest.java
+++ b/src/Coalesce.Framework.Persister.Accumulo/src/test/java/com/incadencecorp/coalesce/framework/persistance/accumulo/Accumulo2SearchTest.java
@@ -50,6 +50,15 @@ public class Accumulo2SearchTest extends AbstractSearchTest<AccumuloSearchPersis
         Assume.assumeTrue(false);
     }
 
+    /**
+     * TODO Need to resolve; Accumulo GeoMesa appears to ignore the startindex
+     */
+    @Override
+    public void testPaging() throws Exception
+    {
+        Assume.assumeTrue(false);
+    }
+
     @Override
     protected AccumuloSearchPersistor createPersister()
     {

--- a/src/Coalesce.Framework.Persister.Elasticsearch/src/main/java/com/incadencecorp/coalesce/framework/persistance/elasticsearch/ElasticSearchQueryRewriter.java
+++ b/src/Coalesce.Framework.Persister.Elasticsearch/src/main/java/com/incadencecorp/coalesce/framework/persistance/elasticsearch/ElasticSearchQueryRewriter.java
@@ -143,12 +143,6 @@ class ElasticSearchQueryRewriter extends DuplicatingFilterVisitor {
         //create a new filter with the rewritten property names
         Query newQuery = new Query(original);
 
-        // Convert to 0 Indexed Paging
-        if (original.getStartIndex() != null && original.getStartIndex() > 0)
-        {
-            newQuery.setStartIndex(original.getStartIndex() - 1);
-        }
-
         // See if a valid feature name was set in the query.  If
         // so make sure it is the first in the list
         if (!StringHelper.isNullOrEmpty(newQuery.getTypeName()) && !newQuery.getTypeName().equalsIgnoreCase("coalesce"))

--- a/src/Coalesce.Framework.Persister.NEO4J/src/main/java/com/incadencecorp/coalesce/framework/persistance/neo4j/Neo4jSearchPersister.java
+++ b/src/Coalesce.Framework.Persister.NEO4J/src/main/java/com/incadencecorp/coalesce/framework/persistance/neo4j/Neo4jSearchPersister.java
@@ -56,7 +56,7 @@ public class Neo4jSearchPersister extends Neo4JPersistor implements ICoalesceSea
     {
         if (query.getStartIndex() == null)
         {
-            query.setStartIndex(1);
+            query.setStartIndex(0);
         }
 
         SearchResults results = new SearchResults();
@@ -190,9 +190,7 @@ public class Neo4jSearchPersister extends Neo4JPersistor implements ICoalesceSea
 
         if (query.getMaxFeatures() > 0)
         {
-            int offset = query.getMaxFeatures() * (query.getStartIndex() - 1);
-
-            limit = String.format("SKIP %s LIMIT %s", offset, query.getMaxFeatures());
+            limit = String.format("SKIP %s LIMIT %s", query.getStartIndex(), query.getMaxFeatures());
         }
 
         return limit;

--- a/src/Coalesce.Framework.Persister.PostgreSQL/src/main/java/com/incadencecorp/coalesce/framework/persistance/postgres/PostGreSQLPersistorExt.java
+++ b/src/Coalesce.Framework.Persister.PostgreSQL/src/main/java/com/incadencecorp/coalesce/framework/persistance/postgres/PostGreSQLPersistorExt.java
@@ -328,7 +328,7 @@ public class PostGreSQLPersistorExt extends PostGreSQLPersistor implements ICoal
     {
         if (query.getStartIndex() == null)
         {
-            query.setStartIndex(1);
+            query.setStartIndex(0);
         }
 
         SearchResults results = new SearchResults();
@@ -339,7 +339,7 @@ public class PostGreSQLPersistorExt extends PostGreSQLPersistor implements ICoal
         {
             // Create SQL Query
             PostGresCoalescePreparedFilter preparedFilter = new PostGresCoalescePreparedFilter(PostGreSQLSettings.getDatabaseSchema());
-            preparedFilter.setPageNumber(query.getStartIndex());
+            preparedFilter.setOffset(query.getStartIndex());
             preparedFilter.setPageSize(query.getMaxFeatures());
             preparedFilter.setSortBy(query.getSortBy());
             preparedFilter.setPropertNames(query.getPropertyNames());

--- a/src/Coalesce.Framework.Persister.PostgreSQL/src/main/java/com/incadencecorp/coalesce/framework/persistance/postgres/PostGresCoalescePreparedFilter.java
+++ b/src/Coalesce.Framework.Persister.PostgreSQL/src/main/java/com/incadencecorp/coalesce/framework/persistance/postgres/PostGresCoalescePreparedFilter.java
@@ -128,7 +128,7 @@ public class PostGresCoalescePreparedFilter extends PostgisPSFilterToSql impleme
     private final List<String> enumList = new ArrayList<>();
     private FilterFactory factory;
 
-    private int pageNumber;
+    private int offset;
     private int pageSize;
     private Capabilities capability;
 
@@ -157,13 +157,13 @@ public class PostGresCoalescePreparedFilter extends PostgisPSFilterToSql impleme
 
     /**
      * @param schema
-     * @param pageNumber
+     * @param offset
      * @param pageSize
      * @param includeDeleted
      * @param dialect
      */
     public PostGresCoalescePreparedFilter(String schema,
-                                          int pageNumber,
+                                          int offset,
                                           int pageSize,
                                           boolean includeDeleted,
                                           PostGISPSDialect dialect)
@@ -175,7 +175,7 @@ public class PostGresCoalescePreparedFilter extends PostgisPSFilterToSql impleme
         currentSRID = SSRID;
         SRIDs.add(currentSRID);
 
-        setPageNumber(pageNumber);
+        setOffset(offset);
         setPageSize(pageSize);
 
         capability = createCapabilities();
@@ -936,15 +936,9 @@ public class PostGresCoalescePreparedFilter extends PostgisPSFilterToSql impleme
      *
      * @param value
      */
-    public void setPageNumber(int value)
+    public void setOffset(int value)
     {
-
-        if (value < 1)
-        {
-            value = 1;
-        }
-
-        pageNumber = value;
+        offset = value < 0 ? 0 : value;
     }
 
     /**
@@ -1102,16 +1096,14 @@ public class PostGresCoalescePreparedFilter extends PostgisPSFilterToSql impleme
      */
     public String getLimit()
     {
-
         String limit = "";
 
         if (pageSize > 0)
         {
-            limit = String.format("LIMIT %s OFFSET %s", pageSize, (pageNumber - 1) * pageSize);
+            limit = String.format("LIMIT %s OFFSET %s", pageSize, offset);
         }
 
         return limit;
-
     }
 
     /**

--- a/src/Coalesce.React/entity-search/src/app.js
+++ b/src/Coalesce.React/entity-search/src/app.js
@@ -23,6 +23,8 @@ export class App extends React.Component {
     this.createQuery = this.createQuery.bind(this);
     this.handleSearch = this.handleSearch.bind(this);
     this.handleSpinner = this.handleSpinner.bind(this);
+    this.handlePageUpdate = this.handlePageUpdate.bind(this);
+    this.handlePageSizeUpdate = this.handlePageSizeUpdate.bind(this);
 
     var cache = {};
 
@@ -36,6 +38,8 @@ export class App extends React.Component {
       key: DEFAULT,
       results: null,
       properties: [],
+      pageSize: 200,
+      pageNum: 1,
       query: this.createQuery()
     }
   }
@@ -109,6 +113,14 @@ export class App extends React.Component {
 
   handleUpdate(data, properties) {
     this.setState(() => {return {query: data, properties: properties}});
+  }
+
+  handlePageUpdate(page) {
+    this.setState(() => {return {pageNum: page}});
+  }
+
+  handlePageSizeUpdate(size) {
+    this.setState(() => {return {pageSize: size}});
   }
 
   handleTemplateLoad(key) {
@@ -217,6 +229,10 @@ export class App extends React.Component {
                 data={query}
                 handleError={this.handleError}
                 handleUpdate={this.handleUpdate}
+                handlePageUpdate={this.handlePageUpdate}
+                handlePageSizeUpdate={this.handlePageSizeUpdate}
+                pageNum={this.state.pageNum}
+                pageSize={this.state.pageSize}
               />
 
             }
@@ -270,8 +286,8 @@ export class App extends React.Component {
     // Create Query
     var query = {
       "type": this.state.key ? this.state.cache[this.state.key].name : undefined,
-      "pageSize": 200,
-      "pageNumber": 1,
+      "pageSize": this.state.pageSize,
+      "pageNumber": this.state.pageNum,
       "propertyNames": [],
       "group": this.state.query
     };
@@ -293,14 +309,6 @@ export class App extends React.Component {
         }
       })
     }
-
-    this.state.query.criteria.forEach(function (criteria) {
-      if (criteria.value2)
-      {
-        criteria.value = criteria.value + " " + criteria.value2;
-        criteria.value2 = undefined;
-      }
-    })
 
     console.log("Index search", this.state.query);
 

--- a/src/Coalesce.React/entity-search/src/filtercreator.js
+++ b/src/Coalesce.React/entity-search/src/filtercreator.js
@@ -127,12 +127,38 @@ class FilterCreator extends React.Component {
             </div>
             <Divider />
             <ExpansionPanelActions  style={{padding: '5px'}}>
+              {!this.props.isChild &&
+                <FieldInput
+                   label="Page"
+                   field={{
+                    key: "pageNum",
+                    value: this.props.pageNum
+                   }}
+                   dataType="INTEGER_TYPE"
+                   onChange={(value) => {
+                     this.props.handlePageUpdate(value);
+                   }}
+                 />
+              }
+              {!this.props.isChild &&
+              <FieldInput
+                 label="Page Size"
+                 field={{
+                   key: "pageSize",
+                   value: this.props.pageSize
+                 }}
+                 dataType="INTEGER_TYPE"
+                 onChange={(value) => {
+                   this.props.handlePageSizeUpdate(value);
+                 }}
+               />
+              }
               <IconButton icon="/images/svg/add.svg" title="Add Criteria" onClick={this.handleAddCriteria} />
               <IconButton icon="/images/svg/new.svg" title="Add Sub Grouping" onClick={this.handleAddGroup}/>
               {this.props.isChild &&
               <IconButton icon="/images/svg/remove.svg" title="Remove Grouping" onClick={this.handleRemoveGroup} />
               }
-            </ExpansionPanelActions>
+              </ExpansionPanelActions>
           </ExpansionPanel>
     )
   }
@@ -452,31 +478,44 @@ function createColumns(that, recordsets) {
 
         if (cell.original.operator === "Between" || cell.original.operator === "During") {
 
+          cell.original.value = undefined;
+          if (!cell.original.values || cell.original.values.length != 2)
+          {
+            cell.original.values = ["", ""]
+          }
           return (
             <Row>
               <Col xs={6}>
                 <FieldInput
-                  field={cell.original}
+                  field={{
+                    key: cell.original.key + "_1",
+                    value: cell.original.values[0]
+                  }}
                   hint={hint}
                   dataType={dataType}
                   attr="value"
                   showLabels={false}
+                  onChange={(value) => cell.original.values[0] = value}
                 />
               </Col>
               <Col xs={6}>
                 <FieldInput
-                  field={cell.original}
+                  field={{
+                    key: cell.original.key + "_2",
+                    value: cell.original.values[1]
+                  }}
                   hint={hint}
                   dataType={dataType}
-                  attr="value2"
+                  attr="value"
                   showLabels={false}
+                  onChange={(value) => cell.original.values[1] = value}
                 />
               </Col>
             </Row>
           )
         } else {
 
-          cell.original.value2 = undefined;
+          cell.original.values = undefined;
 
           return (
             <FieldInput

--- a/src/Coalesce.Services/Search/service-data/src/main/java/com/incadencecorp/coalesce/services/search/service/data/controllers/SearchDataController.java
+++ b/src/Coalesce.Services/Search/service-data/src/main/java/com/incadencecorp/coalesce/services/search/service/data/controllers/SearchDataController.java
@@ -40,7 +40,17 @@ import org.geotools.referencing.CRS;
 import org.geotools.temporal.object.DefaultInstant;
 import org.geotools.temporal.object.DefaultPeriod;
 import org.geotools.temporal.object.DefaultPosition;
-import org.opengis.filter.*;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.PropertyIsBetween;
+import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.PropertyIsGreaterThan;
+import org.opengis.filter.PropertyIsGreaterThanOrEqualTo;
+import org.opengis.filter.PropertyIsLessThan;
+import org.opengis.filter.PropertyIsLessThanOrEqualTo;
+import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.PropertyIsNotEqualTo;
+import org.opengis.filter.PropertyIsNull;
 import org.opengis.filter.capability.FilterCapabilities;
 import org.opengis.filter.capability.GeometryOperand;
 import org.opengis.filter.capability.Operator;
@@ -64,7 +74,13 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.rmi.RemoteException;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Converts a list of options into an OGC filter and passes it along to a search
@@ -158,7 +174,8 @@ public class SearchDataController {
             query.setFilter(filter);
             query.setProperties(properties);
             query.setSortBy(sortBy);
-            query.setStartIndex(searchQuery.getPageNumber());
+            query.setStartIndex(
+                    searchQuery.getPageNumber() > 0 ? (searchQuery.getPageNumber() - 1) * searchQuery.getPageSize() : 0);
             query.setMaxFeatures(searchQuery.getPageSize());
 
             return createResponse(framework.searchBulk(searchQuery.getCapabilities(), query).get(0), properties);

--- a/src/Coalesce.Services/Search/service-data/src/main/java/com/incadencecorp/coalesce/services/search/service/data/controllers/SearchDataController.java
+++ b/src/Coalesce.Services/Search/service-data/src/main/java/com/incadencecorp/coalesce/services/search/service/data/controllers/SearchDataController.java
@@ -426,7 +426,7 @@ public class SearchDataController {
                 criteriaFilter = ff.like(property, criteria.getValue());
                 break;
             case PropertyIsBetween.NAME:
-                String[] values = criteria.getValue().split(" ");
+                String[] values = criteria.getValues().toArray(new String[0]);
                 if (values.length != 2)
                 {
                     throw new CoalesceException(
@@ -435,7 +435,7 @@ public class SearchDataController {
                 criteriaFilter = ff.between(property, ff.literal(values[0]), ff.literal(values[1]));
                 break;
             case During.NAME:
-                String[] times = criteria.getValue().split(" ");
+                String[] times = criteria.getValues().toArray(new String[0]);
                 if (times.length != 2)
                 {
                     throw new CoalesceException(

--- a/src/Coalesce.Services/Search/service-data/src/main/java/com/incadencecorp/coalesce/services/search/service/data/model/SearchCriteria.java
+++ b/src/Coalesce.Services/Search/service-data/src/main/java/com/incadencecorp/coalesce/services/search/service/data/model/SearchCriteria.java
@@ -17,6 +17,9 @@
 
 package com.incadencecorp.coalesce.services.search.service.data.model;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 public class SearchCriteria {
 
@@ -24,65 +27,75 @@ public class SearchCriteria {
     private String recordset;
     private String field;
     private String operator;
-    private String value;
+    private List<String> values = new ArrayList<>();
     private boolean isNot;
     private boolean matchCase;
-    
+
     public String getKey()
     {
         return key;
     }
-    
+
     public void setKey(String key)
     {
         this.key = key;
     }
-    
+
     public String getRecordset()
     {
         return recordset;
     }
-    
+
     public void setRecordset(String recordset)
     {
         this.recordset = recordset;
     }
-    
+
     public String getField()
     {
         return field;
     }
-    
+
     public void setField(String field)
     {
         this.field = field;
     }
-    
+
     public String getOperator()
     {
         return operator;
     }
-    
+
     public void setOperator(String value)
     {
         this.operator = value;
     }
-    
+
     public String getValue()
     {
-        return value;
+        return values.size() >= 1 ? values.get(0) : null;
     }
-    
+
     public void setValue(String value)
     {
-        this.value = value;
+        setValues(Collections.singletonList(value));
     }
-    
+
+    public void setValues(List<String> values)
+    {
+        this.values.addAll(values);
+    }
+
+    public List<String> getValues()
+    {
+        return values;
+    }
+
     public boolean isMatchCase()
     {
         return matchCase;
     }
-    
+
     public void setMatchCase(boolean matchCase)
     {
         this.matchCase = matchCase;

--- a/src/Coalesce.Services/Search/service/src/main/java/com/incadencecorp/coalesce/services/search/service/tasks/SearchDataObjectTask.java
+++ b/src/Coalesce.Services/Search/service/src/main/java/com/incadencecorp/coalesce/services/search/service/tasks/SearchDataObjectTask.java
@@ -17,29 +17,12 @@
 
 package com.incadencecorp.coalesce.services.search.service.tasks;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
-import javax.sql.rowset.CachedRowSet;
-import javax.xml.parsers.ParserConfigurationException;
-
-import com.incadencecorp.coalesce.search.api.SearchResults;
-import org.geotools.data.Query;
-import org.geotools.filter.SortByImpl;
-import org.opengis.filter.expression.PropertyName;
-import org.opengis.filter.sort.SortBy;
-import org.opengis.filter.sort.SortOrder;
-import org.xml.sax.SAXException;
-
 import com.incadencecorp.coalesce.api.EResultStatus;
 import com.incadencecorp.coalesce.common.exceptions.CoalesceException;
 import com.incadencecorp.coalesce.framework.tasks.AbstractTask;
 import com.incadencecorp.coalesce.framework.tasks.TaskParameters;
 import com.incadencecorp.coalesce.search.api.ICoalesceSearchPersistor;
+import com.incadencecorp.coalesce.search.api.SearchResults;
 import com.incadencecorp.coalesce.search.factory.CoalescePropertyFactory;
 import com.incadencecorp.coalesce.search.filter.FilterUtil;
 import com.incadencecorp.coalesce.services.api.search.HitType;
@@ -47,6 +30,21 @@ import com.incadencecorp.coalesce.services.api.search.QueryResultType;
 import com.incadencecorp.coalesce.services.api.search.QueryResultsType;
 import com.incadencecorp.coalesce.services.api.search.QueryType;
 import com.incadencecorp.coalesce.services.api.search.SortByType;
+import org.geotools.data.Query;
+import org.geotools.filter.SortByImpl;
+import org.opengis.filter.expression.PropertyName;
+import org.opengis.filter.sort.SortBy;
+import org.opengis.filter.sort.SortOrder;
+import org.xml.sax.SAXException;
+
+import javax.sql.rowset.CachedRowSet;
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 public class SearchDataObjectTask extends AbstractTask<QueryType, QueryResultsType, ICoalesceSearchPersistor> {
 
@@ -71,7 +69,8 @@ public class SearchDataObjectTask extends AbstractTask<QueryType, QueryResultsTy
                 SortByType sort = parameters.getParams().getSortBy().get(ii);
                 PropertyName property = CoalescePropertyFactory.getFilterFactory().property(sort.getPropertyName());
 
-                switch (sort.getSortOrder()) {
+                switch (sort.getSortOrder())
+                {
                 case ASC:
                     sortby[ii] = new SortByImpl(property, SortOrder.ASCENDING);
                     break;
@@ -83,7 +82,8 @@ public class SearchDataObjectTask extends AbstractTask<QueryType, QueryResultsTy
 
             Query query = new Query("coalesce", FilterUtil.fromXml(parameters.getParams().getFilter()));
             query.setPropertyNames(properties);
-            query.setStartIndex(parameters.getParams().getPageNumber());
+            query.setStartIndex(parameters.getParams().getPageNumber() > 0 ? (parameters.getParams().getPageNumber() - 1)
+                    * parameters.getParams().getPageSize() : 0);
             query.setMaxFeatures(parameters.getParams().getPageSize());
             query.setSortBy(sortby);
 

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/persistance/CoalesceDataConnectorBase.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/persistance/CoalesceDataConnectorBase.java
@@ -66,6 +66,53 @@ public abstract class CoalesceDataConnectorBase implements AutoCloseable {
         _conn.setAutoCommit(autocommit);
     }
 
+    public final ResultSet executeQuery(final String sql, Integer max, final CoalesceParameter... parameters) throws SQLException
+    {
+        ResultSet results = null;
+        openDataConnection();
+
+        if (LOGGER.isTraceEnabled())
+        {
+            LOGGER.trace("Executing: {}", sql);
+        }
+
+        PreparedStatement stmt = _conn.prepareStatement(sql);
+        if (max != null)
+        {
+            stmt.setMaxRows(max);
+        }
+
+        if (parameters != null)
+        {
+            if (LOGGER.isTraceEnabled() && parameters.length > 0)
+            {
+                LOGGER.trace("Parameters:");
+            }
+
+            // Add Parameters
+            for (int ii = 0; ii < parameters.length; ii++)
+            {
+                if (LOGGER.isTraceEnabled())
+                {
+                    LOGGER.trace("\t{}:{}", parameters[ii].getValue(), parameters[ii].getType());
+                }
+
+                stmt.setObject(ii + 1, parameters[ii].getValue(), parameters[ii].getType());
+            }
+        }
+
+        if (LOGGER.isTraceEnabled())
+        {
+            LOGGER.trace("Prepared Statement: " + stmt.toString());
+        }
+
+        results = stmt.executeQuery();
+
+        // stmt.close(); // Cannot close here or ResultSet is closed. Possible
+        // resource leak.
+        return results;
+    }
+
     /**
      * Returns the results from the executed SQL Command.
      *


### PR DESCRIPTION
Updated persisters to consistently use the startIndex as an offset instead of a page number. The SearchDataController converts the page number into an offset.