### PR TITLE
#104 Resolved Map GeoServer URL Issue

### DIFF
--- a/src/Coalesce.React/map-viewer/src/app.js
+++ b/src/Coalesce.React/map-viewer/src/app.js
@@ -250,8 +250,8 @@ fetchCapabilities(url) {
     return (
       <div>
         <MapView
-          geoserver={this.state.geoserver}
-          workspace={this.state.workspace}
+          geoserver={this.props.geoserver}
+          workspace={this.props.workspace}
           styles={this.state.styles}
           availableLayers={this.state.availableLayers}
           selectedLayers={this.state.selectedLayers}


### PR DESCRIPTION
Base URL was incorrectly loading from the state instead of the passed in properties.