### PR TITLE
Feature cleanup

### DIFF
--- a/src/Coalesce.Bom/pom.xml
+++ b/src/Coalesce.Bom/pom.xml
@@ -27,6 +27,7 @@
         <accumulo.version>1.7.4</accumulo.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>4.2.2.RELEASE</spring.version>
+        <joda.version>2.9.7</joda.version>
 
         <dependency.bndlib.version>2.4.0</dependency.bndlib.version>
         <bundle-plugin.version>3.5.0</bundle-plugin.version>

--- a/src/Coalesce.Bom/pom.xml
+++ b/src/Coalesce.Bom/pom.xml
@@ -28,6 +28,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>4.2.2.RELEASE</spring.version>
         <joda.version>2.9.7</joda.version>
+        <slf4j.version>1.7.5</slf4j.version>
 
         <dependency.bndlib.version>2.4.0</dependency.bndlib.version>
         <bundle-plugin.version>3.5.0</bundle-plugin.version>

--- a/src/Coalesce.Bundles/bundle-geomesa/pom.xml
+++ b/src/Coalesce.Bundles/bundle-geomesa/pom.xml
@@ -55,23 +55,11 @@
 <!-- 			<groupId>org.locationtech.geomesa</groupId> -->
 <!-- 			<artifactId>geomesa-accumulo-datastore_2.11</artifactId> -->
 <!-- 			<version>1.3.1</version> -->
-<!-- 			<exclusions> -->
-<!-- 				<exclusion> -->
-<!-- 					<artifactId>joda-time</artifactId> -->
-<!-- 					<groupId>joda-time</groupId> -->
-<!-- 				</exclusion> -->
-<!-- 			</exclusions> -->
 <!-- 		</dependency> -->
 <!-- 		<dependency> -->
 <!-- 			<groupId>org.locationtech.geomesa</groupId> -->
 <!-- 			<artifactId>geomesa-utils_2.11</artifactId> -->
 <!-- 			<version>1.3.1</version> -->
-<!-- 			<exclusions> -->
-<!-- 				<exclusion> -->
-<!-- 					<artifactId>joda-time</artifactId> -->
-<!-- 					<groupId>joda-time</groupId> -->
-<!-- 				</exclusion> -->
-<!-- 			</exclusions> -->
 <!-- 		</dependency> -->
 	</dependencies>
 

--- a/src/Coalesce.Core.Feature/pom.xml
+++ b/src/Coalesce.Core.Feature/pom.xml
@@ -83,7 +83,19 @@
 
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.jaxb.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
+            <version>${jackson.jaxb.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
             <version>${jackson.jaxb.version}</version>
             <scope>provided</scope>
         </dependency>

--- a/src/Coalesce.Core.Feature/pom.xml
+++ b/src/Coalesce.Core.Feature/pom.xml
@@ -68,6 +68,13 @@
         <!-- Provided Dependencies -->
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
             <groupId>com.vividsolutions</groupId>
             <artifactId>jts</artifactId>
             <version>1.13</version>

--- a/src/Coalesce.Core.Feature/pom.xml
+++ b/src/Coalesce.Core.Feature/pom.xml
@@ -43,14 +43,6 @@
                     <artifactId>metadata-extractor</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.vividsolutions</groupId>
-                    <artifactId>jts</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.adobe.xmp</groupId>
                     <artifactId>xmpcore</artifactId>
                 </exclusion>
@@ -58,9 +50,42 @@
         </dependency>
 
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.9.7</version>
+            <groupId>com.incadencecorp.coalesce</groupId>
+            <artifactId>coalesce-search</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.geotools</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.geotools.xsd</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Provided Dependencies -->
+
+        <dependency>
+            <groupId>com.vividsolutions</groupId>
+            <artifactId>jts</artifactId>
+            <version>1.13</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.jaxb.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${felix.osgi.version}</version>
+            <scope>provided</scope>
         </dependency>
 
     </dependencies>

--- a/src/Coalesce.Core.Feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Core.Feature/src/main/feature/feature.xml
@@ -20,5 +20,6 @@
 	<feature name="${project.artifactId}">
 		<feature prerequisite="false" dependency="true">cxf</feature>
 		<feature prerequisite="false" dependency="true">cxf-jackson</feature>
+		<bundle start-level="75">mvn:com.incadencecorp.coalesce.bundles/bundle-geotools/${project.version}</bundle>
 	</feature>
 </features>

--- a/src/Coalesce.Feature/pom.xml
+++ b/src/Coalesce.Feature/pom.xml
@@ -69,11 +69,13 @@
 			<classifier>features</classifier>
 		</dependency>
 		<!-- Required - Updating the CXF version for some reason is excluding this dependency -->
+		<!--
 		<dependency>
 			<groupId>org.apache.cxf.karaf</groupId>
 			<artifactId>cxf-karaf-commands</artifactId>
 			<version>${cxf.version}</version>
 		</dependency>
+		-->
 
 	</dependencies>
 

--- a/src/Coalesce.Feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Feature/src/main/feature/feature.xml
@@ -14,15 +14,15 @@
 		<feature prerequisite="false" dependency="false">coalesce-frontend</feature>
 		<feature prerequisite="false" dependency="false">coalesce-javadocs</feature>
 	</feature>
+	<!--
 	<feature name="spifly" start-level="99">
 		<bundle>mvn:org.apache.aries.spifly/org.apache.aries.spifly.dynamic.bundle/1.0.8</bundle>
 		<bundle>mvn:org.ow2.asm/asm-all/5.2</bundle>
 		<bundle>mvn:org.apache.aries/org.apache.aries.util/1.1.3</bundle>
-	</feature>	
+	</feature>
+	-->
 	<feature name="coalesce-frontend" version="${project.version}">
-		<feature prerequisite="false" dependency="false">coalesce-crud-service-feature</feature>
 		<feature prerequisite="false" dependency="false">coalesce-crud-service-data-feature</feature>
-		<feature prerequisite="false" dependency="false">coalesce-search-service-feature</feature>
 		<feature prerequisite="false" dependency="false">coalesce-search-service-data-feature</feature>
 		<feature prerequisite="false" dependency="false">coalesce-react-feature</feature>
 	</feature>

--- a/src/Coalesce.Framework.Persistance/accumulo/feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Framework.Persistance/accumulo/feature/src/main/feature/feature.xml
@@ -3,8 +3,6 @@
 	name="coalesce-services">
 	<feature name="${project.artifactId}">
         <feature prerequisite="false" dependency="true">coalesce-core-feature</feature>
-		<bundle start-level="75">mvn:com.incadencecorp.coalesce.bundles/bundle-geotools/${project.version}
-		</bundle>
 		<bundle start-level="75">mvn:com.incadencecorp.coalesce.bundles/bundle-geomesa/${project.version}
 		</bundle>
 	</feature>

--- a/src/Coalesce.Framework.Persistance/derby/feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Framework.Persistance/derby/feature/src/main/feature/feature.xml
@@ -4,7 +4,5 @@
 	<feature name="${project.artifactId}">
 		<feature prerequisite="false" dependency="true">coalesce-core-feature
 		</feature>
-		<bundle start-level="75">mvn:com.incadencecorp.coalesce.bundles/bundle-geotools/${project.version}
-		</bundle>
 	</feature>
 </features>

--- a/src/Coalesce.Framework.Persistance/elasticsearch/feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Framework.Persistance/elasticsearch/feature/src/main/feature/feature.xml
@@ -3,8 +3,6 @@
 	name="coalesce-services">
 	<feature name="${project.artifactId}">
         <feature prerequisite="false" dependency="true">coalesce-core-feature</feature>
-		<bundle start-level="75">mvn:com.incadencecorp.coalesce.bundles/bundle-geotools/${project.version}
-		</bundle>
 		<bundle start-level="75">mvn:com.incadencecorp.coalesce.bundles/bundle-ironhide/${project.version}
 		</bundle>
 	</feature>

--- a/src/Coalesce.Framework.Persistance/neo4j/feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Framework.Persistance/neo4j/feature/src/main/feature/feature.xml
@@ -3,7 +3,5 @@
 	name="coalesce-services">
 	<feature name="${project.artifactId}">
         <feature prerequisite="false" dependency="true">coalesce-core-feature</feature>
-		<bundle start-level="75">mvn:com.incadencecorp.coalesce.bundles/bundle-geotools/${project.version}
-		</bundle>
 	</feature>
 </features>

--- a/src/Coalesce.Framework.Persistance/postgres/feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Framework.Persistance/postgres/feature/src/main/feature/feature.xml
@@ -3,7 +3,5 @@
 	name="coalesce-services">
 	<feature name="${project.artifactId}">
         <feature prerequisite="false" dependency="true">coalesce-core-feature</feature>
-		<bundle start-level="75">mvn:com.incadencecorp.coalesce.bundles/bundle-geotools/${project.version}
-		</bundle>
 	</feature>
 </features>

--- a/src/Coalesce.Framework.Persistance/rest/feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Framework.Persistance/rest/feature/src/main/feature/feature.xml
@@ -5,7 +5,5 @@
         <feature prerequisite="false" dependency="true">cxf</feature>
         <feature prerequisite="false" dependency="true">cxf-jackson</feature>
         <feature prerequisite="false" dependency="true">coalesce-core-feature</feature>
-		<bundle start-level="75">mvn:com.incadencecorp.coalesce.bundles/bundle-geotools/${project.version}
-		</bundle>
 	</feature>
 </features>

--- a/src/Coalesce.Framework.Persistance/soap/feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Framework.Persistance/soap/feature/src/main/feature/feature.xml
@@ -21,7 +21,5 @@
     <feature name="${project.artifactId}">
         <feature prerequisite="false" dependency="true">cxf</feature>
         <feature prerequisite="false" dependency="true">coalesce-core-feature</feature>
-        <bundle start-level="75">mvn:com.incadencecorp.coalesce.bundles/bundle-geotools/${project.version}
-        </bundle>
     </feature>
 </features>

--- a/src/Coalesce.Framework.Persister.Accumulo/pom.xml
+++ b/src/Coalesce.Framework.Persister.Accumulo/pom.xml
@@ -49,13 +49,6 @@
 			<artifactId>coalesce-search</artifactId>
 		</dependency>
 
-		<dependency>
-			<artifactId>joda-time</artifactId>
-			<groupId>joda-time</groupId>
-			<version>2.3</version>
-			<scope>provided</scope>
-		</dependency>
-
 		<!-- Accumulo Dependencies -->
 		<dependency>
 			<groupId>org.apache.accumulo</groupId>
@@ -63,29 +56,17 @@
 			<version>${accumulo.version}</version>
 		</dependency>
 
-
 		<dependency>
 			<groupId>org.locationtech.geomesa</groupId>
 			<artifactId>geomesa-accumulo-datastore_2.11</artifactId>
 			<version>${accumulo.geomesa.version}</version>
 			<scope>runtime</scope>
-			<exclusions>
-				<exclusion>
-					<artifactId>joda-time</artifactId>
-					<groupId>joda-time</groupId>
-				</exclusion>
-			</exclusions>
 		</dependency>
+
 		<!-- <dependency> -->
 		<!-- <groupId>org.locationtech.geomesa</groupId> -->
 		<!-- <artifactId>geomesa-utils_2.11</artifactId> -->
 		<!-- <version>1.3.1</version> -->
-		<!-- <exclusions> -->
-		<!-- <exclusion> -->
-		<!-- <artifactId>joda-time</artifactId> -->
-		<!-- <groupId>joda-time</groupId> -->
-		<!-- </exclusion> -->
-		<!-- </exclusions> -->
 		<!-- </dependency> -->
 
 		<!-- Test Dependencies -->

--- a/src/Coalesce.Framework.Persister.Elasticsearch/pom.xml
+++ b/src/Coalesce.Framework.Persister.Elasticsearch/pom.xml
@@ -73,12 +73,6 @@
         </dependency>
 
         <dependency>
-            <artifactId>joda-time</artifactId>
-            <groupId>joda-time</groupId>
-            <version>2.8</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-main</artifactId>
             <version>${geotools.version}</version>

--- a/src/Coalesce.NiFi/processors/json-csv-extractor/json-csv-nar/pom.xml
+++ b/src/Coalesce.NiFi/processors/json-csv-extractor/json-csv-nar/pom.xml
@@ -33,11 +33,6 @@
             <artifactId>json-csv-processors</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.4</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/src/Coalesce.Pom/pom.xml
+++ b/src/Coalesce.Pom/pom.xml
@@ -97,13 +97,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.4</version>
-            <!--<version>1.6.2</version>-->
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>1.7.5</version>

--- a/src/Coalesce.Pom/pom.xml
+++ b/src/Coalesce.Pom/pom.xml
@@ -96,16 +96,12 @@
             <version>${felix.osgi.version}</version>
             <scope>provided</scope>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.5</version>
-            <scope>provided</scope>
-        </dependency>
+        <!-- Test Dependencies -->
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.5</version>
+            <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/Coalesce.Pom/pom.xml
+++ b/src/Coalesce.Pom/pom.xml
@@ -90,12 +90,6 @@
 
     <dependencies>
 
-        <dependency>
-            <groupId>org.apache.felix</groupId>
-            <artifactId>org.osgi.core</artifactId>
-            <version>${felix.osgi.version}</version>
-            <scope>provided</scope>
-        </dependency>
         <!-- Test Dependencies -->
 
         <dependency>

--- a/src/Coalesce.Services/CRUD/service-data-feature/pom.xml
+++ b/src/Coalesce.Services/CRUD/service-data-feature/pom.xml
@@ -1,24 +1,76 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
-	<artifactId>coalesce-crud-service-data-feature</artifactId>
-	<packaging>feature</packaging>
-	<name>Coalesce CRUD Data Service Feature</name>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>coalesce-crud-service-data-feature</artifactId>
+    <packaging>feature</packaging>
+    <name>Coalesce CRUD Data Service Feature</name>
 
-	<parent>
-		<groupId>com.incadencecorp.coalesce.services.crud</groupId>
-		<artifactId>coalesce-crud-parent</artifactId>
-		<version>0.0.36-SNAPSHOT</version>
-		<relativePath>..</relativePath>
-	</parent>
+    <parent>
+        <groupId>com.incadencecorp.coalesce.services.crud</groupId>
+        <artifactId>coalesce-crud-parent</artifactId>
+        <version>0.0.36-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.karaf.tooling</groupId>
-				<artifactId>karaf-maven-plugin</artifactId>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.incadencecorp.coalesce.services.crud</groupId>
+            <artifactId>coalesce-crud-service-data-jaxrs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.incadencecorp.coalesce.services.search</groupId>
+            <artifactId>coalesce-search-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.incadencecorp.coalesce</groupId>
+            <artifactId>coalesce-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.incadencecorp.coalesce</groupId>
+            <artifactId>coalesce-search</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <version>${cxf.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.jaxb.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb2_commons</groupId>
+            <artifactId>jaxb2-basics</artifactId>
+            <version>1.11.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf.xjc-utils</groupId>
+            <artifactId>cxf-xjc-runtime</artifactId>
+            <version>${cxf.xjc.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
 
 </project>

--- a/src/Coalesce.Services/CRUD/service-data-feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Services/CRUD/service-data-feature/src/main/feature/feature.xml
@@ -5,8 +5,8 @@
 		<feature prerequisite="false" dependency="true">blueprint-web</feature>
 		<feature prerequisite="false" dependency="true">spring-dm-web</feature>
 		<feature prerequisite="false" dependency="true">cxf-jaxrs</feature>
+		<feature prerequisite="false" dependency="true">cxf-jackson</feature>
 		<feature prerequisite="false" dependency="true">coalesce-search-service-feature</feature>
-        <bundle start-level="75">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson.jaxb.version}</bundle>
         <bundle start-level="75">mvn:com.incadencecorp.coalesce.services.crud/coalesce-crud-service-data/${project.version}</bundle>
         <bundle start-level="75">mvn:com.incadencecorp.coalesce.services.crud/coalesce-crud-service-data-jaxrs/${project.version}</bundle>
 	</feature>

--- a/src/Coalesce.Services/CRUD/service-data-feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Services/CRUD/service-data-feature/src/main/feature/feature.xml
@@ -3,11 +3,9 @@
 	name="coalesce-services">
 	<feature name="${project.artifactId}">
 		<feature prerequisite="false" dependency="true">blueprint-web</feature>
-		<feature prerequisite="false" dependency="true">spring-dm-web</feature>
-		<feature prerequisite="false" dependency="true">cxf-jaxrs</feature>
 		<feature prerequisite="false" dependency="true">cxf-jackson</feature>
+		<feature prerequisite="false" dependency="true">cxf-jaxrs</feature>
+        <feature prerequisite="false" dependency="true">cxf-xjc-runtime</feature>
 		<feature prerequisite="false" dependency="true">coalesce-search-service-feature</feature>
-        <bundle start-level="75">mvn:com.incadencecorp.coalesce.services.crud/coalesce-crud-service-data/${project.version}</bundle>
-        <bundle start-level="75">mvn:com.incadencecorp.coalesce.services.crud/coalesce-crud-service-data-jaxrs/${project.version}</bundle>
 	</feature>
 </features>

--- a/src/Coalesce.Services/CRUD/service-data-jaxrs/pom.xml
+++ b/src/Coalesce.Services/CRUD/service-data-jaxrs/pom.xml
@@ -30,11 +30,6 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.jaxb.version}</version>
         </dependency>
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.4</version>
-		</dependency>
 
 	</dependencies>
 

--- a/src/Coalesce.Services/CRUD/service-data/pom.xml
+++ b/src/Coalesce.Services/CRUD/service-data/pom.xml
@@ -34,12 +34,6 @@
 			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.4</version>
-		</dependency>
-		
 		<!-- Test Dependencies -->
 		<dependency>
 			<groupId>com.incadencecorp.coalesce.services.search</groupId>

--- a/src/Coalesce.Services/CRUD/service-feature/pom.xml
+++ b/src/Coalesce.Services/CRUD/service-feature/pom.xml
@@ -27,36 +27,29 @@
             <groupId>com.incadencecorp.coalesce.services.crud</groupId>
             <artifactId>coalesce-crud-service</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.geotools</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.geotools.xsd</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>xercesImpl</artifactId>
-                    <groupId>xerces</groupId>
-                </exclusion>
-                <exclusion>
-                    <artifactId>stax-api</artifactId>
-                    <groupId>stax</groupId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.jvnet.jaxb2_commons</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.apache.cxf.xjc-utils</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.incadencecorp.coalesce</groupId>
-                    <artifactId>coalesce-core</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.incadencecorp.coalesce</groupId>
+            <artifactId>coalesce-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.incadencecorp.coalesce</groupId>
+            <artifactId>coalesce-search</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb2_commons</groupId>
+            <artifactId>jaxb2-basics</artifactId>
+            <version>1.11.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf.xjc-utils</groupId>
+            <artifactId>cxf-xjc-runtime</artifactId>
+            <version>${cxf.xjc.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/src/Coalesce.Services/CRUD/service-feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Services/CRUD/service-feature/src/main/feature/feature.xml
@@ -2,6 +2,7 @@
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0"
 	name="coalesce-services">
 	<feature name="${project.artifactId}">
+        <feature prerequisite="false" dependency="true">cxf-jackson</feature>
         <feature prerequisite="false" dependency="true">cxf-jaxws</feature>
         <feature prerequisite="false" dependency="true">cxf-xjc-runtime</feature>
         <feature prerequisite="false" dependency="true">coalesce-core-feature</feature>

--- a/src/Coalesce.Services/Search/service-data-feature/pom.xml
+++ b/src/Coalesce.Services/Search/service-data-feature/pom.xml
@@ -21,4 +21,50 @@
 		</plugins>
 	</build>
 
+	<dependencies>
+        <dependency>
+            <groupId>com.incadencecorp.coalesce.services.search</groupId>
+            <artifactId>coalesce-search-service-data-jaxrs</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.incadencecorp.coalesce</groupId>
+            <artifactId>coalesce-core</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.incadencecorp.coalesce</groupId>
+            <artifactId>coalesce-search</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf</groupId>
+            <artifactId>cxf-rt-frontend-jaxrs</artifactId>
+            <version>${cxf.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.jaxb.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb2_commons</groupId>
+            <artifactId>jaxb2-basics</artifactId>
+            <version>1.11.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf.xjc-utils</groupId>
+            <artifactId>cxf-xjc-runtime</artifactId>
+            <version>${cxf.xjc.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
 </project>

--- a/src/Coalesce.Services/Search/service-data-feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Services/Search/service-data-feature/src/main/feature/feature.xml
@@ -5,8 +5,8 @@
 		<feature prerequisite="false" dependency="true">blueprint-web</feature>
 		<feature prerequisite="false" dependency="true">spring-dm-web</feature>
 		<feature prerequisite="false" dependency="true">cxf-jaxrs</feature>
+		<feature prerequisite="false" dependency="true">cxf-jackson</feature>
 		<feature prerequisite="false" dependency="true">coalesce-search-service-feature</feature>
-        <bundle start-level="75">mvn:com.fasterxml.jackson.jaxrs/jackson-jaxrs-json-provider/${jackson.jaxb.version}</bundle>
         <bundle start-level="75">mvn:com.incadencecorp.coalesce.services.search/coalesce-search-service-data/${project.version}</bundle>
         <bundle start-level="75">mvn:com.incadencecorp.coalesce.services.search/coalesce-search-service-data-jaxrs/${project.version}</bundle>
 	</feature>

--- a/src/Coalesce.Services/Search/service-data-feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Services/Search/service-data-feature/src/main/feature/feature.xml
@@ -3,11 +3,8 @@
 	name="coalesce-services">
 	<feature name="${project.artifactId}">
 		<feature prerequisite="false" dependency="true">blueprint-web</feature>
-		<feature prerequisite="false" dependency="true">spring-dm-web</feature>
-		<feature prerequisite="false" dependency="true">cxf-jaxrs</feature>
 		<feature prerequisite="false" dependency="true">cxf-jackson</feature>
-		<feature prerequisite="false" dependency="true">coalesce-search-service-feature</feature>
-        <bundle start-level="75">mvn:com.incadencecorp.coalesce.services.search/coalesce-search-service-data/${project.version}</bundle>
-        <bundle start-level="75">mvn:com.incadencecorp.coalesce.services.search/coalesce-search-service-data-jaxrs/${project.version}</bundle>
+		<feature prerequisite="false" dependency="true">cxf-jaxrs</feature>
+        <feature prerequisite="false" dependency="true">cxf-xjc-runtime</feature>
 	</feature>
 </features>

--- a/src/Coalesce.Services/Search/service-data-jaxrs/pom.xml
+++ b/src/Coalesce.Services/Search/service-data-jaxrs/pom.xml
@@ -30,11 +30,6 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.jaxb.version}</version>
         </dependency>
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.4</version>
-		</dependency>
 
 	</dependencies>
 

--- a/src/Coalesce.Services/Search/service-data-springboot/pom.xml
+++ b/src/Coalesce.Services/Search/service-data-springboot/pom.xml
@@ -48,12 +48,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.4</version>
-		</dependency>
-
-		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 			<version>1.5.2.RELEASE</version>

--- a/src/Coalesce.Services/Search/service-data/pom.xml
+++ b/src/Coalesce.Services/Search/service-data/pom.xml
@@ -20,12 +20,6 @@
 			<version>${project.version}</version>
 		</dependency>
 
-		<dependency>
-			<groupId>joda-time</groupId>
-			<artifactId>joda-time</artifactId>
-			<version>2.4</version>
-		</dependency>
-		
 		<!-- Test Dependencies -->
 		<dependency>
 			<groupId>com.incadencecorp.coalesce.services.search</groupId>

--- a/src/Coalesce.Services/Search/service-feature/pom.xml
+++ b/src/Coalesce.Services/Search/service-feature/pom.xml
@@ -27,37 +27,30 @@
 			<groupId>com.incadencecorp.coalesce.services.search</groupId>
 			<artifactId>coalesce-search-service</artifactId>
 			<version>${project.version}</version>
-			<exclusions>
-				<exclusion>
-					<groupId>org.geotools</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.geotools.xsd</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-				<exclusion>
-					<artifactId>xercesImpl</artifactId>
-					<groupId>xerces</groupId>
-				</exclusion>
-				<exclusion>
-					<artifactId>stax-api</artifactId>
-					<groupId>stax</groupId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.jvnet.jaxb2_commons</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>org.apache.cxf.xjc-utils</groupId>
-					<artifactId>*</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>com.incadencecorp.coalesce</groupId>
-					<artifactId>coalesce-core</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
+
+        <dependency>
+            <groupId>com.incadencecorp.coalesce</groupId>
+            <artifactId>coalesce-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.incadencecorp.coalesce</groupId>
+            <artifactId>coalesce-search</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jvnet.jaxb2_commons</groupId>
+            <artifactId>jaxb2-basics</artifactId>
+            <version>1.11.1</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.cxf.xjc-utils</groupId>
+            <artifactId>cxf-xjc-runtime</artifactId>
+            <version>${cxf.xjc.version}</version>
+            <scope>provided</scope>
+        </dependency>
 	</dependencies>
 
 </project>

--- a/src/Coalesce.Services/Search/service-feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Services/Search/service-feature/src/main/feature/feature.xml
@@ -2,10 +2,9 @@
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0"
 	name="coalesce-services">
 	<feature name="${project.artifactId}">
+        <feature prerequisite="false" dependency="true">cxf-jackson</feature>
         <feature prerequisite="false" dependency="true">cxf-jaxws</feature>
         <feature prerequisite="false" dependency="true">cxf-xjc-runtime</feature>
         <feature prerequisite="false" dependency="true">coalesce-core-feature</feature>
-		<!-- <feature>camel-jms</feature> -->
-		<!-- <feature>activemq-camel</feature> -->
 	</feature>
 </features>

--- a/src/Coalesce.Services/Search/service-feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Services/Search/service-feature/src/main/feature/feature.xml
@@ -7,7 +7,5 @@
         <feature prerequisite="false" dependency="true">coalesce-core-feature</feature>
 		<!-- <feature>camel-jms</feature> -->
 		<!-- <feature>activemq-camel</feature> -->
-		<bundle start-level="75">mvn:com.incadencecorp.coalesce.bundles/bundle-geotools/${project.version}
-		</bundle>
 	</feature>
 </features>

--- a/src/Coalesce.Services/network/feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Services/network/feature/src/main/feature/feature.xml
@@ -21,6 +21,7 @@
 	name="coalesce-services">
 	<feature name="${project.artifactId}">
 		<feature prerequisite="false" dependency="true">cxf-jaxrs</feature>
+		<feature prerequisite="false" dependency="true">cxf-jackson</feature>
         <feature prerequisite="false" dependency="true">cxf-xjc-runtime</feature>
 		<feature prerequisite="false" dependency="true">coalesce-core-feature</feature>
 	</feature>

--- a/src/Coalesce.Synchronizer/drone/pom.xml
+++ b/src/Coalesce.Synchronizer/drone/pom.xml
@@ -144,8 +144,9 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.1</version>
+            <version>${jackson.jaxb.version}</version>
         </dependency>
+
     </dependencies>
 
 </project>

--- a/src/Coalesce.Synchronizer/drone/pom.xml
+++ b/src/Coalesce.Synchronizer/drone/pom.xml
@@ -133,13 +133,8 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.5</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.5</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/Coalesce.Synchronizer/drone/pom.xml
+++ b/src/Coalesce.Synchronizer/drone/pom.xml
@@ -146,11 +146,6 @@
             <artifactId>jackson-core</artifactId>
             <version>2.9.1</version>
         </dependency>
-        <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-            <version>2.4</version>
-        </dependency>
     </dependencies>
 
 </project>

--- a/src/Coalesce.Synchronizer/feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Synchronizer/feature/src/main/feature/feature.xml
@@ -2,7 +2,7 @@
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0" name="coalesce-synchronizer-feature">
     <feature name="${project.artifactId}">
         <feature>scr</feature>
-        <feature prerequisite="false" dependency="true" version="${cxf.version}">cxf</feature>
+        <feature prerequisite="false" dependency="true">cxf</feature>
         <feature prerequisite="false" dependency="true">coalesce-core-feature</feature>
     </feature>
 </features>

--- a/src/Coalesce.Synchronizer/feature/src/main/feature/feature.xml
+++ b/src/Coalesce.Synchronizer/feature/src/main/feature/feature.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0" name="coalesce-synchronizer-feature">
     <feature name="${project.artifactId}">
-        <feature>scr</feature>
-        <feature prerequisite="false" dependency="true">cxf</feature>
         <feature prerequisite="false" dependency="true">coalesce-core-feature</feature>
     </feature>
 </features>

--- a/src/Coalesce/pom.xml
+++ b/src/Coalesce/pom.xml
@@ -111,6 +111,12 @@
             <artifactId>json</artifactId>
             <version>20160807</version>
         </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+            <version>${joda.version}</version>
+        </dependency>
         <dependency>
             <!-- Required for DocumentProperties -->
             <groupId>jaxen</groupId>

--- a/src/Coalesce/pom.xml
+++ b/src/Coalesce/pom.xml
@@ -120,6 +120,14 @@
         </dependency>
 
         <dependency>
+            <!-- Required for BundleContext -->
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>${felix.osgi.version}</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
             <version>${joda.version}</version>

--- a/src/Coalesce/pom.xml
+++ b/src/Coalesce/pom.xml
@@ -106,6 +106,13 @@
     </build>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>


### PR DESCRIPTION
Took lessons learned from another program and refactored the provided dependencies in Coalesce.Pom into transient dependencies of coalesce-core. Then marked them as provided within the coalesce-core-feature's pom. This allows the transient dependencies to correctly propagate to artifacts that depend on them without polluting our Karaf features.