### PR TITLE
#167 Deduplication Operation

### DIFF
--- a/src/Coalesce.Synchronizer/api/src/main/java/com/incadencecorp/coalesce/synchronizer/api/common/AbstractOperation.java
+++ b/src/Coalesce.Synchronizer/api/src/main/java/com/incadencecorp/coalesce/synchronizer/api/common/AbstractOperation.java
@@ -246,16 +246,13 @@ public abstract class AbstractOperation<T extends AbstractOperationTask> extends
 
                     for (String[] subset : subsets)
                     {
-                        for (ICoalescePersistor target : targets)
-                        {
-                            T task = createTask();
-                            task.setParameters(parameters);
-                            task.setSource(source);
-                            task.setRowset(rowset);
-                            task.setSubset(subset);
-                            task.setTarget(target);
-                            tasks.add(task);
-                        }
+                        T task = createTask();
+                        task.setParameters(parameters);
+                        task.setSource(source);
+                        task.setRowset(rowset);
+                        task.setSubset(subset);
+                        task.setTarget(targets);
+                        tasks.add(task);
                     }
 
                 }

--- a/src/Coalesce.Synchronizer/api/src/main/java/com/incadencecorp/coalesce/synchronizer/api/common/AbstractScan.java
+++ b/src/Coalesce.Synchronizer/api/src/main/java/com/incadencecorp/coalesce/synchronizer/api/common/AbstractScan.java
@@ -17,6 +17,7 @@
 
 package com.incadencecorp.coalesce.synchronizer.api.common;
 
+import com.incadencecorp.coalesce.api.CoalesceErrors;
 import com.incadencecorp.coalesce.common.exceptions.CoalesceException;
 import com.incadencecorp.coalesce.common.helpers.StringHelper;
 import com.incadencecorp.coalesce.framework.CoalesceComponentImpl;
@@ -32,7 +33,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.rowset.CachedRowSet;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Abstract implementation to be used as the base of all scanner

--- a/src/Coalesce.Synchronizer/api/src/test/java/com/incadencecorp/coalesce/synchronizer/api/common/mocks/MockOperation.java
+++ b/src/Coalesce.Synchronizer/api/src/test/java/com/incadencecorp/coalesce/synchronizer/api/common/mocks/MockOperation.java
@@ -17,11 +17,6 @@
 
 package com.incadencecorp.coalesce.synchronizer.api.common.mocks;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import javax.sql.rowset.CachedRowSet;
-
 import com.incadencecorp.coalesce.common.exceptions.CoalescePersistorException;
 import com.incadencecorp.coalesce.common.helpers.StringHelper;
 import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
@@ -29,9 +24,13 @@ import com.incadencecorp.coalesce.search.factory.CoalescePropertyFactory;
 import com.incadencecorp.coalesce.synchronizer.api.common.AbstractOperation;
 import com.incadencecorp.coalesce.synchronizer.api.common.AbstractOperationTask;
 
+import javax.sql.rowset.CachedRowSet;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Mock Operation Implementation
- * 
+ *
  * @author n78554
  */
 public class MockOperation extends AbstractOperation<AbstractOperationTask> {
@@ -40,7 +39,7 @@ public class MockOperation extends AbstractOperation<AbstractOperationTask> {
 
     /**
      * Sets the title which will be set by this operation on each entity.
-     * 
+     *
      * @param title
      */
     public void setTitle(String title)
@@ -58,24 +57,20 @@ public class MockOperation extends AbstractOperation<AbstractOperationTask> {
             {
                 if (!StringHelper.isNullOrEmpty(title))
                 {
-                    for (String key : keys)
-                    {
-                        // Change Title
-                        CoalesceEntity[] entities = source.getEntity(key);
+                    // Change Title
+                    CoalesceEntity[] entities = source.getEntity(keys);
 
-                        for (CoalesceEntity entity : entities)
-                        {
-                            entity.setTitle(title);
-                            target.saveEntity(false, entity);
-                        }
+                    for (CoalesceEntity entity : entities)
+                    {
+                        entity.setTitle(title);
                     }
+
+                    return saveWork(false, entities);
                 }
                 else
                 {
                     throw new CoalescePersistorException("Failed", null);
                 }
-
-                return true;
             }
 
         };

--- a/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/operations/CopyOperationImpl.java
+++ b/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/operations/CopyOperationImpl.java
@@ -72,7 +72,7 @@ public class CopyOperationImpl extends AbstractOperation<AbstractOperationTask> 
                 // Copy to Targets
                 if (LOGGER.isDebugEnabled())
                 {
-                    LOGGER.debug("Processing {} key(s) for {}", entities.length, target.getClass().getName());
+                    LOGGER.debug("Processing {} key(s)", entities.length);
                     LOGGER.trace("Details:");
 
                     for (CoalesceEntity entity : entities)
@@ -82,7 +82,7 @@ public class CopyOperationImpl extends AbstractOperation<AbstractOperationTask> 
 
                 }
 
-                target.saveEntity(false, entities);
+                saveWork(false, entities);
 
                 return true;
             }

--- a/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/operations/DeleteDuplicatesOperation.java
+++ b/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/operations/DeleteDuplicatesOperation.java
@@ -1,0 +1,258 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.synchronizer.service.operations;
+
+import com.incadencecorp.coalesce.api.CoalesceErrors;
+import com.incadencecorp.coalesce.common.exceptions.CoalescePersistorException;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.framework.persistance.ICoalescePersistor;
+import com.incadencecorp.coalesce.search.api.ICoalesceSearchPersistor;
+import com.incadencecorp.coalesce.search.api.SearchResults;
+import com.incadencecorp.coalesce.search.factory.CoalescePropertyFactory;
+import com.incadencecorp.coalesce.synchronizer.api.common.AbstractOperation;
+import com.incadencecorp.coalesce.synchronizer.api.common.AbstractOperationTask;
+import org.geotools.data.Query;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.expression.PropertyName;
+import org.opengis.filter.sort.SortBy;
+import org.opengis.filter.sort.SortOrder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.sql.rowset.CachedRowSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * This implementation takes a list of keys and based on the specified unique fields checks for duplicates. If found based on
+ * configuration this operation will either mark them as deleted or permanently delete the entities.
+ *
+ * @author Derek Clemenzi
+ * @see #PARAM_MARK_AS_DELETED
+ * @see #PARAM_UNIQUE_KEY
+ */
+public class DeleteDuplicatesOperation extends AbstractOperation<AbstractOperationTask> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteDuplicatesOperation.class);
+    private static final FilterFactory2 FF = CoalescePropertyFactory.getFilterFactory();
+
+    /**
+     * (Boolean) If true then the entities are only marked as deleted; otherwise they are physically deleted.
+     */
+    public static final String PARAM_MARK_AS_DELETED = DeleteOperationImpl.class.getName() + ".markOnly";
+
+    /**
+     * (CSV) Comma separated list of fields that uniquely identifies an entity.
+     */
+    public static final String PARAM_UNIQUE_KEY = DeleteOperationImpl.class.getName() + ".fields";
+
+    // Default Parameter Values
+    private static final String DEFAULT_MARK_AS_DELETED = Boolean.TRUE.toString();
+    private static final String DEFAULT_UNIQUE_KEY = CoalescePropertyFactory.getEntityId().toString();
+
+    private boolean allowRemoval = false;
+    private Set<String> fields = new HashSet<>();
+
+    @Override
+    public void setProperties(Map<String, String> params)
+    {
+        super.setProperties(params);
+
+        allowRemoval = !Boolean.parseBoolean(parameters.getOrDefault(PARAM_MARK_AS_DELETED, DEFAULT_MARK_AS_DELETED));
+        fields.addAll(Arrays.asList(parameters.getOrDefault(PARAM_UNIQUE_KEY, DEFAULT_UNIQUE_KEY).split("[,]")));
+    }
+
+    @Override
+    protected Set<String> getAdditionalRequiredColumns()
+    {
+        return fields;
+    }
+
+    @Override
+    protected AbstractOperationTask createTask()
+    {
+        return new AbstractOperationTask() {
+
+            @Override
+            protected Boolean doWork(String[] keys, CachedRowSet rowset) throws CoalescePersistorException
+            {
+                if (!(source instanceof ICoalesceSearchPersistor))
+                {
+                    throw new IllegalArgumentException(String.format(CoalesceErrors.NOT_INITIALIZED,
+                                                                     ICoalesceSearchPersistor.class));
+                }
+
+                try
+                {
+                    if (rowset.first())
+                    {
+                        List<String> keyList = Arrays.asList(keys);
+                        Set<String> keysToDelete = new HashSet<>();
+
+                        // Determine Column Mapping
+                        Map<String, Integer> fieldIdx = getColumnMapping(rowset.getMetaData(), fields);
+
+                        do
+                        {
+                            // Entity Key is always the first column
+                            String key = rowset.getString(1);
+
+                            if (keyList.contains(key))
+                            {
+                                // Extract key's unique values
+                                Map<String, String> fieldValues = new HashMap<>();
+
+                                for (String field : fields)
+                                {
+                                    fieldValues.put(field, rowset.getString(fieldIdx.get(field)));
+                                }
+
+                                keysToDelete.addAll(runDeduplicationCheck(fieldValues, source));
+                            }
+                        }
+                        while (rowset.next());
+
+                        CoalesceEntity[] entities = source.getEntity(keysToDelete.toArray(new String[keysToDelete.size()]));
+
+                        for (CoalesceEntity entity : entities)
+                        {
+                            entity.markAsDeleted();
+                        }
+
+                        return saveWork(allowRemoval, entities);
+                    }
+                }
+                catch (SQLException e)
+                {
+                    // Rethrow as a Coalesce Exception
+                    throw new CoalescePersistorException(e);
+                }
+
+                return true;
+            }
+        };
+    }
+
+    /**
+     * @return a list of keys that are consider duplicates and should be deleted.
+     */
+    private static List<String> runDeduplicationCheck(Map<String, String> fieldValues, ICoalescePersistor source)
+            throws CoalescePersistorException
+    {
+        List<String> keysToDelete = new ArrayList<>();
+
+        // Create de-duplication query
+        List<Filter> filters = new ArrayList<>();
+
+        for (Map.Entry<String, String> entry : fieldValues.entrySet())
+        {
+            filters.add(FF.equal(FF.property(entry.getKey()), FF.literal(entry.getValue()), false));
+        }
+
+        List<PropertyName> props = new ArrayList<>();
+        props.add(CoalescePropertyFactory.getLastModified());
+
+        Query query = new Query();
+        query.setProperties(props);
+        query.setFilter(FF.and(filters));
+        query.setSortBy(new SortBy[] {
+                FF.sort(CoalescePropertyFactory.getLastModified().getPropertyName(), SortOrder.DESCENDING)
+        });
+
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("Duplication Check Query: {}", query.getFilter());
+        }
+
+        // Execute Query
+        SearchResults results = ((ICoalesceSearchPersistor) source).search(query);
+
+        if (results.isSuccessful())
+        {
+            try (CachedRowSet rows = results.getResults())
+            {
+                // Has Duplicates?
+                if (rows.size() > 1 && rows.first())
+                {
+                    // Keep the first entry and delete the rest
+                    while (rows.next())
+                    {
+                        String key = rows.getString(1);
+                        keysToDelete.add(key);
+                        LOGGER.debug("Duplicate Detected ({})", key);
+                    }
+                }
+            }
+            catch (SQLException e)
+            {
+                // Rethrow as a Coalesce Exception
+                throw new CoalescePersistorException(e);
+            }
+        }
+        else
+        {
+            throw new CoalescePersistorException("(FAILED) Executing de-duplication query: " + results.getError());
+        }
+
+        return keysToDelete;
+    }
+
+    /**
+     * @return a mapping of property names to the column indexes
+     */
+    private static Map<String, Integer> getColumnMapping(ResultSetMetaData metadata, Collection<String> propertyNames)
+            throws SQLException
+    {
+        Map<String, Integer> fieldIdx = new HashMap<>();
+
+        for (String field : propertyNames)
+        {
+            fieldIdx.put(field, getPropertyIdx(metadata, field));
+        }
+
+        return fieldIdx;
+    }
+
+    /**
+     * @return the column index for the specified property name.
+     */
+    private static int getPropertyIdx(ResultSetMetaData metadata, String propertyName) throws SQLException
+    {
+        String columnName = CoalescePropertyFactory.getColumnName(propertyName);
+
+        for (int ii = 1; ii <= metadata.getColumnCount(); ii++)
+        {
+            if (metadata.getColumnName(ii).equalsIgnoreCase(columnName))
+            {
+                return ii;
+            }
+        }
+
+        throw new SQLException(String.format(CoalesceErrors.NOT_FOUND, "Column", columnName));
+    }
+}

--- a/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/operations/DeleteOperationImpl.java
+++ b/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/operations/DeleteOperationImpl.java
@@ -56,14 +56,14 @@ public class DeleteOperationImpl extends AbstractOperation<AbstractOperationTask
             @Override
             protected Boolean doWork(String[] keys, CachedRowSet rowset) throws CoalescePersistorException
             {
-                CoalesceEntity[] entities = target.getEntity(keys);
+                CoalesceEntity[] entities = source.getEntity(keys);
 
                 for (CoalesceEntity entity : entities)
                 {
                     entity.markAsDeleted();
                 }
 
-                return target.saveEntity(allowRemoval, entities);
+                return saveWork(allowRemoval, entities);
             }
         };
     }

--- a/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/operations/UpdateVersionOperationImpl.java
+++ b/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/operations/UpdateVersionOperationImpl.java
@@ -147,7 +147,7 @@ public class UpdateVersionOperationImpl extends AbstractOperation<AbstractOperat
                 {
                     if (!isDryrun)
                     {
-                        target.saveEntity(false, updatedEntities.toArray(new CoalesceEntity[updatedEntities.size()]));
+                        return saveWork(false, updatedEntities.toArray(new CoalesceEntity[updatedEntities.size()]));
                     }
                     else
                     {

--- a/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/operations/VerifyOperationImpl.java
+++ b/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/operations/VerifyOperationImpl.java
@@ -58,7 +58,10 @@ public class VerifyOperationImpl extends AbstractOperation<AbstractOperationTask
             @Override
             protected Boolean doWork(String[] keys, CachedRowSet rowset) throws CoalescePersistorException
             {
-                missing.addAll(verify(target, keys));
+                for (ICoalescePersistor target : targets)
+                {
+                    missing.addAll(verify(target, keys));
+                }
 
                 if (!missing.isEmpty())
                 {

--- a/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/scanners/AfterLastModifiedScanImpl2.java
+++ b/src/Coalesce.Synchronizer/service/src/main/java/com/incadencecorp/coalesce/synchronizer/service/scanners/AfterLastModifiedScanImpl2.java
@@ -229,8 +229,9 @@ public class AfterLastModifiedScanImpl2 extends AbstractScan {
             if (loader != null && pendingLastScan != null)
             {
                 loader.setProperty(SynchronizerParameters.PARAM_SCANNER_LAST_SUCCESS, lastScanned);
-                LOGGER.info("Last Successful Scan: {}", lastScanned);
             }
+
+            LOGGER.info("Last Successful Scan: {}", lastScanned);
         }
         else
         {

--- a/src/Coalesce.Synchronizer/service/src/test/java/com/incadencecorp/coalesce/synchronizer/service/tests/DeleteDuplicatesOperationTest.java
+++ b/src/Coalesce.Synchronizer/service/src/test/java/com/incadencecorp/coalesce/synchronizer/service/tests/DeleteDuplicatesOperationTest.java
@@ -1,0 +1,146 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.synchronizer.service.tests;
+
+import com.incadencecorp.coalesce.common.helpers.JodaDateTimeHelper;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntityTemplate;
+import com.incadencecorp.coalesce.framework.datamodel.ECoalesceObjectStatus;
+import com.incadencecorp.coalesce.framework.datamodel.TestEntity;
+import com.incadencecorp.coalesce.framework.datamodel.TestRecord;
+import com.incadencecorp.coalesce.framework.persistance.ICoalescePersistor;
+import com.incadencecorp.coalesce.framework.persistance.derby.DerbyPersistor;
+import com.incadencecorp.coalesce.search.CoalesceSearchFramework;
+import com.incadencecorp.coalesce.search.factory.CoalescePropertyFactory;
+import com.incadencecorp.coalesce.search.resultset.CoalesceResultSet;
+import com.incadencecorp.coalesce.synchronizer.service.operations.DeleteDuplicatesOperation;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.sql.rowset.CachedRowSet;
+import javax.sql.rowset.RowSetProvider;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * These test ensure the {@link DeleteDuplicatesOperation} detects and removes duplicate entities.
+ *
+ * @author Derek Clemenzi
+ */
+public class DeleteDuplicatesOperationTest {
+
+    /**
+     * Initialize components used within these tests.
+     */
+    @BeforeClass
+    public static void initialize() throws Exception
+    {
+        ICoalescePersistor persistor = new DerbyPersistor();
+        persistor.registerTemplate(CoalesceEntityTemplate.create(new TestEntity()));
+    }
+
+    /**
+     * This test verifies correct behaviour of the operation.
+     */
+    @Test
+    public void testOperation() throws Exception
+    {
+        ICoalescePersistor persistor = new DerbyPersistor();
+
+        CoalesceSearchFramework framework = new CoalesceSearchFramework();
+        framework.setAuthoritativePersistor(persistor);
+
+        // Create Entities
+        String key = UUID.randomUUID().toString();
+
+        TestEntity entity1 = new TestEntity();
+        entity1.initialize();
+        TestRecord record1 = entity1.addRecord1();
+        record1.getStringField().setValue("HelloWorld");
+        record1.getIntegerField().setValue(5);
+        entity1.setLastModified(JodaDateTimeHelper.nowInUtc());
+
+        TestEntity entity2 = new TestEntity();
+        entity2.initialize();
+        TestRecord record2 = entity2.addRecord1();
+        record2.getStringField().setValue(record1.getStringField().getValue());
+        record2.getIntegerField().setValue(record1.getIntegerField().getValue());
+        entity2.setLastModified(entity1.getLastModified().plusMinutes(10));
+
+        TestEntity entity3 = new TestEntity();
+        entity3.initialize();
+        TestRecord record3 = entity3.addRecord1();
+        record3.getStringField().setValue(record1.getStringField().getValue());
+        record3.getIntegerField().setValue(10);
+        entity3.setLastModified(entity1.getLastModified().plusMinutes(5));
+
+        // Save Entities
+        framework.saveCoalesceEntity(entity1, entity2, entity3);
+
+        List<String> fields = new ArrayList<>();
+        fields.add(CoalescePropertyFactory.getFieldProperty(record1.getStringField()).toString());
+        fields.add(CoalescePropertyFactory.getFieldProperty(record1.getIntegerField()).toString());
+
+        // Create Operation
+        Map<String, String> params = new HashMap<>();
+        params.put(DeleteDuplicatesOperation.PARAM_MARK_AS_DELETED, "true");
+        params.put(DeleteDuplicatesOperation.PARAM_UNIQUE_KEY, String.join(",", fields.toArray(new String[fields.size()])));
+
+        DeleteDuplicatesOperation operation = new DeleteDuplicatesOperation();
+        operation.setSource(persistor);
+        operation.setTarget(persistor);
+        operation.setProperties(params);
+
+        // Execute Operation
+        List<Object[]> rows = new ArrayList<>();
+        rows.add(new Object[] { key, record1.getIntegerField().getValue(), record1.getStringField().getValue() });
+
+        List<String> columns = new ArrayList<>();
+        columns.add(CoalescePropertyFactory.getColumnName(CoalescePropertyFactory.getEntityKey()));
+
+        for (String field : operation.getRequiredColumns())
+        {
+            columns.add(CoalescePropertyFactory.getColumnName(field));
+        }
+
+        CachedRowSet rowset = RowSetProvider.newFactory().createCachedRowSet();
+        rowset.populate(new CoalesceResultSet(rows.iterator(), columns.toArray(new String[columns.size()])));
+
+        operation.execute(framework, rowset);
+
+        // Verify
+        CoalesceEntity[] entities = framework.getCoalesceEntities(entity1.getKey(), entity2.getKey(), entity3.getKey());
+
+        Assert.assertEquals(ECoalesceObjectStatus.DELETED, entities[0].getStatus());
+        Assert.assertEquals(ECoalesceObjectStatus.ACTIVE, entities[1].getStatus());
+        Assert.assertEquals(ECoalesceObjectStatus.ACTIVE, entities[2].getStatus());
+
+        // Cleanup
+        entity1.markAsDeleted();
+        entity2.markAsDeleted();
+        entity3.markAsDeleted();
+
+        framework.saveCoalesceEntity(true, entity1, entity2, entity3);
+    }
+
+}


### PR DESCRIPTION
Implemented a generic operation to delete (or mark as deleted) duplicate entities from the database by specifying the fields that make them unique as a comma separated list. 