### PR TITLE
Derby Last Modified Check

### DIFF
--- a/src/Coalesce.Framework.Persistance/derby/persister/src/main/java/com/incadencecorp/coalesce/framework/persistance/derby/DerbyPersistor.java
+++ b/src/Coalesce.Framework.Persistance/derby/persister/src/main/java/com/incadencecorp/coalesce/framework/persistance/derby/DerbyPersistor.java
@@ -650,6 +650,8 @@ public class DerbyPersistor extends CoalescePersistorBase implements ICoalesceSe
      */
     private boolean checkLastModified(CoalesceObject coalesceObject, CoalesceDataConnectorBase conn) throws SQLException
     {
+        return true;
+        /*
         boolean isOutOfDate = true;
 
         // Get LastModified from the Database
@@ -674,6 +676,7 @@ public class DerbyPersistor extends CoalescePersistorBase implements ICoalesceSe
         }
 
         return isOutOfDate;
+        //*/
     }
 
     @Override


### PR DESCRIPTION
Removed the last modified check which was causing issues with some of the unit tests in BDP. This check is primarily to reduce the number of writes but since this persister is not used in production performance is not a concern