### PR TITLE
Resolves #192 Operation Thread Safety 

### DIFF
--- a/src/Coalesce.Synchronizer/api/src/main/java/com/incadencecorp/coalesce/synchronizer/api/common/AbstractOperationTask.java
+++ b/src/Coalesce.Synchronizer/api/src/main/java/com/incadencecorp/coalesce/synchronizer/api/common/AbstractOperationTask.java
@@ -22,6 +22,8 @@ import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
 import com.incadencecorp.coalesce.framework.persistance.ICoalescePersistor;
 
 import javax.sql.rowset.CachedRowSet;
+import java.io.IOException;
+import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -32,7 +34,7 @@ import java.util.concurrent.Callable;
  *
  * @author n78554
  */
-public abstract class AbstractOperationTask implements Callable<Boolean> {
+public abstract class AbstractOperationTask implements Callable<Boolean>, AutoCloseable {
 
     protected ICoalescePersistor source;
     protected ICoalescePersistor[] targets;
@@ -111,6 +113,19 @@ public abstract class AbstractOperationTask implements Callable<Boolean> {
     public String[] getErrorSubset()
     {
         return getSubset();
+    }
+
+    @Override
+    public void close() throws IOException
+    {
+        try
+        {
+            rowset.close();
+        }
+        catch (SQLException e)
+        {
+            throw new IOException(e);
+        }
     }
 
     /**

--- a/src/Coalesce.Synchronizer/service/src/test/java/com/incadencecorp/coalesce/synchronizer/service/tests/PropertyDriverImplTest.java
+++ b/src/Coalesce.Synchronizer/service/src/test/java/com/incadencecorp/coalesce/synchronizer/service/tests/PropertyDriverImplTest.java
@@ -46,8 +46,6 @@ public class PropertyDriverImplTest {
     @Test
     public void testDriver() throws Exception
     {
-        String newTitle = "Hello World";
-
         Map<String, String> params = new HashMap<>();
         params.put(SynchronizerParameters.PARAM_DRIVER_INTERVAL_UNITS, TimeUnit.SECONDS.toString());
         params.put(SynchronizerParameters.PARAM_DRIVER_DELAY, "1");
@@ -65,7 +63,6 @@ public class PropertyDriverImplTest {
         scan.setup();
 
         MockOperation operation = new MockOperation();
-        operation.setTitle(newTitle);
         operation.setSource(source);
         operation.setTarget(source);
 
@@ -89,7 +86,7 @@ public class PropertyDriverImplTest {
 
         driver.start();
 
-        Assert.assertEquals(newTitle, source.getEntity(entity.getKey())[0].getTitle());
+        Assert.assertEquals(entity.getKey(), source.getEntity(entity.getKey())[0].getTitle());
 
         driver.stop();
     }


### PR DESCRIPTION
Resolves #192 by ensuring the CachedRowSet passed into each operation is its own instance making them thread safe.