### PR TITLE
Setting CreatedBy and ModifiedBy

### DIFF
--- a/src/Coalesce.React/entity-editor/src/app.js
+++ b/src/Coalesce.React/entity-editor/src/app.js
@@ -46,6 +46,12 @@ export class App extends React.Component {
 
   }
 
+  handleError = (message) => {
+    this.setState({
+      error: message
+    });
+  }
+
   handleSaveEntity() {
     const that = this;
 
@@ -176,7 +182,7 @@ export class App extends React.Component {
       <div>
         <Menu logoSrc={this.props.icon} title={this.props.title} items={menuItems}/>
         <Paper style={{padding: '5px', margin: '10px'}}>
-          <EntityView data={entity} template={template} isNew={isNew} />
+          <EntityView data={entity} template={template} isNew={isNew} onHandleError={this.handleError}/>
           <DialogPrompt
             title="Enter Entity Key"
             value=''

--- a/src/Coalesce.React/entity-editor/src/entity.js
+++ b/src/Coalesce.React/entity-editor/src/entity.js
@@ -12,6 +12,7 @@ export class EntityView extends React.Component {
 
   constructor(props) {
     super(props);
+
     this.state = {
         data: props.data,
         isNew: props.isNew
@@ -19,9 +20,19 @@ export class EntityView extends React.Component {
   }
 
   componentWillReceiveProps(nextProps) {
+
+    var revisions = [];
+
+    if (nextProps.data) {
+      for (var ii=1; ii<=nextProps.data.objectVersion; ii++) {
+          revisions.push({enum: ii, label: ii})
+      }
+    }
+
     this.setState({
       data: nextProps.data,
-      isNew: nextProps.isNew
+      isNew: nextProps.isNew,
+      revisions: revisions
     })
   }
 
@@ -35,8 +46,12 @@ export class EntityView extends React.Component {
     this.props.saveEntity(this.state.data, this.state.isNew, this);
   }
 
+  handleError = (message) => {
+    this.props.onHandleError(message);
+  }
+
   render() {
-    const {data} = this.state;
+    const {data, revisions} = this.state;
 
     var template = this.props.template;
 
@@ -46,7 +61,7 @@ export class EntityView extends React.Component {
           <Col xs={2}>
             <label>Title</label>
           </Col>
-          <Col xs={4}>
+          <Col xs={10}>
             {data &&
               <FieldInput
                 field={data}
@@ -56,19 +71,13 @@ export class EntityView extends React.Component {
               />
             }
           </Col>
+        </Row>
+        <Row>
           <Col xs={2}>
             <label>Name</label>
           </Col>
           <Col xs={4}>
             {template != null ? template.name : ''}
-          </Col>
-        </Row>
-        <Row>
-          <Col xs={2}>
-            <label>Created</label>
-          </Col>
-          <Col xs={4}>
-            {data != null ? data.dateCreated : ''}
           </Col>
           <Col xs={2}>
             <label>Source</label>
@@ -79,16 +88,53 @@ export class EntityView extends React.Component {
         </Row>
         <Row>
           <Col xs={2}>
+            <label>Version</label>
+          </Col>
+          <Col xs={4}>
+            {template != null ? template.version : ''}
+          </Col>
+          <Col xs={2}>
+            <label>Revision</label>
+          </Col>
+          <Col xs={4}>
+            {data &&
+              <FieldInput
+                field={data}
+                dataType="ENUMERATION_TYPE"
+                attr="objectVersion"
+                options={revisions}
+                showLabels={false}
+                onChange={this.handleError}
+              />
+            }
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={2}>
+            <label>Created</label>
+          </Col>
+          <Col xs={4}>
+            {data != null ? data.dateCreated : ''}
+          </Col>
+          <Col xs={2}>
+            <label>By</label>
+          </Col>
+          <Col xs={4}>
+            {data != null ? data.createdBy : ''}
+          </Col>
+        </Row>
+        <Row>
+          <Col xs={2}>
             <label>Last Modified</label>
           </Col>
           <Col xs={4}>
             {data != null ? data.lastModified : ''}
           </Col>
           <Col xs={2}>
-            <label>Version</label>
+            <label>By</label>
           </Col>
           <Col xs={4}>
-            {template != null ? template.version : ''}
+            {data != null ? data.modifiedBy : ''}
           </Col>
         </Row>
         <Row>
@@ -98,14 +144,6 @@ export class EntityView extends React.Component {
           <Col xs={4}>
             {data != null ? data.key : ''}
           </Col>
-          <Col xs={2}>
-            <label>Revision</label>
-          </Col>
-          <Col xs={4}>
-            {data != null ? data.objectVersion : ''}
-          </Col>
-        </Row>
-        <Row>
           <Col xs={2}>
             <label>Status</label>
           </Col>
@@ -120,6 +158,9 @@ export class EntityView extends React.Component {
               />
             }
           </Col>
+        </Row>
+        <Row>
+
         </Row>
         { template != null && data != null &&
         <Tabs>

--- a/src/Coalesce.Search/src/main/java/com/incadencecorp/coalesce/search/factory/CoalescePropertyFactory.java
+++ b/src/Coalesce.Search/src/main/java/com/incadencecorp/coalesce/search/factory/CoalescePropertyFactory.java
@@ -256,7 +256,7 @@ public class CoalescePropertyFactory {
      */
     public static PropertyName getEntityId()
     {
-        return getFilterFactory().property(COALESCE_ENTITY_TABLE + "entityid");
+        return getFilterFactory().property(COALESCE_ENTITY_TABLE + CoalesceEntity.ATTRIBUTE_ENTITYID);
     }
 
     /**
@@ -264,7 +264,7 @@ public class CoalescePropertyFactory {
      */
     public static PropertyName getEntityIdType()
     {
-        return getFilterFactory().property(COALESCE_ENTITY_TABLE + "entityidtype");
+        return getFilterFactory().property(COALESCE_ENTITY_TABLE + CoalesceEntity.ATTRIBUTE_ENTITYIDTYPE);
     }
 
     /**
@@ -272,7 +272,7 @@ public class CoalescePropertyFactory {
      */
     public static PropertyName getEntityStatus()
     {
-        return getFilterFactory().property(COALESCE_ENTITY_TABLE + "status");
+        return getFilterFactory().property(COALESCE_ENTITY_TABLE + CoalesceEntity.ATTRIBUTE_STATUS);
     }
 
     /**

--- a/src/Coalesce.Search/src/test/java/com/incadencecorp/coalesce/search/AbstractSearchTest.java
+++ b/src/Coalesce.Search/src/test/java/com/incadencecorp/coalesce/search/AbstractSearchTest.java
@@ -151,7 +151,7 @@ public abstract class AbstractSearchTest<T extends ICoalescePersistor & ICoalesc
         TestEntity entity = new TestEntity();
         entity.initialize();
         entity.setModifiedBy(user1);
-        entity.createHistory(user2, "", 1);
+        entity.createHistory(user2, "", 2);
 
         persister.saveEntity(false, entity);
 

--- a/src/Coalesce.Services/CRUD/service-data-jaxrs/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/jaxrs/EntityDataControllerJaxRS.java
+++ b/src/Coalesce.Services/CRUD/service-data-jaxrs/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/jaxrs/EntityDataControllerJaxRS.java
@@ -1,7 +1,6 @@
 package com.incadencecorp.coalesce.services.crud.service.data.jaxrs;
 
-import com.incadencecorp.coalesce.framework.persistance.ICoalescePersistor;
-import com.incadencecorp.coalesce.services.crud.api.ICrudClient;
+import com.incadencecorp.coalesce.framework.CoalesceFramework;
 import com.incadencecorp.coalesce.services.crud.service.data.controllers.EntityDataController;
 
 import java.rmi.RemoteException;
@@ -18,9 +17,9 @@ public class EntityDataControllerJaxRS extends EntityDataController implements I
      *
      * @see EntityDataController
      */
-    public EntityDataControllerJaxRS(ICrudClient crud, ICoalescePersistor persister)
+    public EntityDataControllerJaxRS(CoalesceFramework framework)
     {
-        super(crud, persister);
+        super(framework);
     }
 
     @Override

--- a/src/Coalesce.Services/CRUD/service-data-jaxrs/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/jaxrs/EntityDataControllerJaxRS.java
+++ b/src/Coalesce.Services/CRUD/service-data-jaxrs/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/jaxrs/EntityDataControllerJaxRS.java
@@ -1,8 +1,12 @@
 package com.incadencecorp.coalesce.services.crud.service.data.jaxrs;
 
+import com.incadencecorp.coalesce.api.CoalesceSimplePrincipal;
+import com.incadencecorp.coalesce.api.ICoalescePrincipal;
 import com.incadencecorp.coalesce.framework.CoalesceFramework;
 import com.incadencecorp.coalesce.services.crud.service.data.controllers.EntityDataController;
 
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
 import java.rmi.RemoteException;
 
 /**
@@ -11,6 +15,9 @@ import java.rmi.RemoteException;
  * @author Derek Clemenzi
  */
 public class EntityDataControllerJaxRS extends EntityDataController implements IEntityDataControllerJaxRS {
+
+    @Context
+    SecurityContext securityContext;
 
     /**
      * Default Constructor
@@ -26,5 +33,18 @@ public class EntityDataControllerJaxRS extends EntityDataController implements I
     public void deleteEntity(String entityKey) throws RemoteException
     {
         this.deleteEntities(new String[] { entityKey });
+    }
+
+    @Override
+    protected ICoalescePrincipal getPrincipal()
+    {
+        if (securityContext != null && securityContext.getUserPrincipal() != null)
+        {
+            return new CoalesceSimplePrincipal(securityContext.getUserPrincipal());
+        }
+        else
+        {
+            return new CoalesceSimplePrincipal("");
+        }
     }
 }

--- a/src/Coalesce.Services/CRUD/service-data-jaxrs/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/jaxrs/LinkageDataControllerJaxRS.java
+++ b/src/Coalesce.Services/CRUD/service-data-jaxrs/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/jaxrs/LinkageDataControllerJaxRS.java
@@ -17,8 +17,13 @@
 
 package com.incadencecorp.coalesce.services.crud.service.data.jaxrs;
 
+import com.incadencecorp.coalesce.api.CoalesceSimplePrincipal;
+import com.incadencecorp.coalesce.api.ICoalescePrincipal;
 import com.incadencecorp.coalesce.search.CoalesceSearchFramework;
 import com.incadencecorp.coalesce.services.crud.service.data.controllers.LinkageDataController;
+
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.SecurityContext;
 
 /**
  * JaxRs Implementation
@@ -26,6 +31,9 @@ import com.incadencecorp.coalesce.services.crud.service.data.controllers.Linkage
  * @author Derek Clemenzi
  */
 public class LinkageDataControllerJaxRS extends LinkageDataController implements ILinkageDataControllerJaxRS {
+
+    @Context
+    SecurityContext securityContext;
 
     /**
      * @param framework
@@ -36,7 +44,16 @@ public class LinkageDataControllerJaxRS extends LinkageDataController implements
         super(framework);
     }
 
+    @Override
+    protected ICoalescePrincipal getPrincipal()
     {
-        super(crud, search);
+        if (securityContext != null && securityContext.getUserPrincipal() != null)
+        {
+            return new CoalesceSimplePrincipal(securityContext.getUserPrincipal());
+        }
+        else
+        {
+            return new CoalesceSimplePrincipal("");
+        }
     }
 }

--- a/src/Coalesce.Services/CRUD/service-data-jaxrs/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/jaxrs/LinkageDataControllerJaxRS.java
+++ b/src/Coalesce.Services/CRUD/service-data-jaxrs/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/jaxrs/LinkageDataControllerJaxRS.java
@@ -18,7 +18,6 @@
 package com.incadencecorp.coalesce.services.crud.service.data.jaxrs;
 
 import com.incadencecorp.coalesce.search.CoalesceSearchFramework;
-import com.incadencecorp.coalesce.services.crud.api.ICrudClient;
 import com.incadencecorp.coalesce.services.crud.service.data.controllers.LinkageDataController;
 
 /**
@@ -28,12 +27,15 @@ import com.incadencecorp.coalesce.services.crud.service.data.controllers.Linkage
  */
 public class LinkageDataControllerJaxRS extends LinkageDataController implements ILinkageDataControllerJaxRS {
 
-    public LinkageDataControllerJaxRS(ICrudClient crud)
+    /**
+     * @param framework
+     * @see LinkageDataController
+     */
+    public LinkageDataControllerJaxRS(CoalesceSearchFramework framework)
     {
-        super(crud);
+        super(framework);
     }
 
-    public LinkageDataControllerJaxRS(ICrudClient crud, CoalesceSearchFramework search)
     {
         super(crud, search);
     }

--- a/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/jobs/CoalesceRequest.java
+++ b/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/jobs/CoalesceRequest.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.services.crud.service.data.controllers.jobs;
+
+import com.incadencecorp.coalesce.services.api.common.BaseRequest;
+
+/**
+ * @author Derek Clemenzi
+ */
+public class CoalesceRequest<T> extends BaseRequest {
+
+    private T params;
+
+    public CoalesceRequest(T params)
+    {
+        this.params = params;
+    }
+
+    public T getParams()
+    {
+        return params;
+    }
+
+    public void setParams(T params)
+    {
+        this.params = params;
+    }
+}

--- a/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/jobs/CreateDataObjectJob.java
+++ b/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/jobs/CreateDataObjectJob.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.services.crud.service.data.controllers.jobs;
+
+import com.incadencecorp.coalesce.framework.CoalesceFramework;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.framework.tasks.AbstractTask;
+import com.incadencecorp.coalesce.services.api.common.ResultsType;
+import com.incadencecorp.coalesce.services.api.common.StringResponse;
+import com.incadencecorp.coalesce.services.common.jobs.AbstractServiceJob;
+import com.incadencecorp.coalesce.services.crud.service.data.controllers.tasks.CreateDataObjectTask;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class CreateDataObjectJob
+        extends AbstractServiceJob<CoalesceRequest<CoalesceEntity[]>, StringResponse, ResultsType, CoalesceFramework> {
+
+    public CreateDataObjectJob(CoalesceRequest<CoalesceEntity[]> request)
+    {
+        super(request);
+    }
+
+    @Override
+    protected Collection<AbstractTask<?, ResultsType, CoalesceFramework>> getTasks(CoalesceRequest<CoalesceEntity[]> request)
+    {
+        List<AbstractTask<?, ResultsType, CoalesceFramework>> tasks = new ArrayList<>();
+
+        for (CoalesceEntity entity : request.getParams())
+        {
+            CreateDataObjectTask task = new CreateDataObjectTask();
+            task.setParams(new CoalesceEntity[] { entity });
+
+            tasks.add(task);
+        }
+
+        return tasks;
+    }
+
+    @Override
+    protected StringResponse createResponse()
+    {
+        return new StringResponse();
+    }
+
+    @Override
+    protected ResultsType createResults()
+    {
+        return new ResultsType();
+    }
+
+}

--- a/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/jobs/RetrieveDataObjectJob.java
+++ b/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/jobs/RetrieveDataObjectJob.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.services.crud.service.data.controllers.jobs;
+
+import com.incadencecorp.coalesce.api.ICoalesceResponseType;
+import com.incadencecorp.coalesce.framework.CoalesceFramework;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.framework.jobs.responses.CoalesceResponseType;
+import com.incadencecorp.coalesce.framework.tasks.AbstractTask;
+import com.incadencecorp.coalesce.services.api.crud.DataObjectKeyRequest;
+import com.incadencecorp.coalesce.services.api.crud.DataObjectKeyType;
+import com.incadencecorp.coalesce.services.common.jobs.AbstractFrameworkServiceJob;
+import com.incadencecorp.coalesce.services.crud.service.data.controllers.tasks.RetrieveDataObjectTask;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class RetrieveDataObjectJob extends
+        AbstractFrameworkServiceJob<DataObjectKeyRequest, ICoalesceResponseType<List<ICoalesceResponseType<CoalesceEntity>>>, ICoalesceResponseType<CoalesceEntity>> {
+
+    public RetrieveDataObjectJob(DataObjectKeyRequest request)
+    {
+        super(request);
+    }
+
+    @Override
+    protected List<AbstractTask<?, ICoalesceResponseType<CoalesceEntity>, CoalesceFramework>> getTasks(DataObjectKeyRequest params)
+    {
+        List<AbstractTask<?, ICoalesceResponseType<CoalesceEntity>, CoalesceFramework>> tasks = new ArrayList<>();
+
+        for (DataObjectKeyType type : params.getKeyList())
+        {
+            RetrieveDataObjectTask task = new RetrieveDataObjectTask();
+            task.setParams(new DataObjectKeyType[] { type
+            });
+
+            tasks.add(task);
+        }
+
+        return tasks;
+    }
+
+    @Override
+    protected ICoalesceResponseType<List<ICoalesceResponseType<CoalesceEntity>>> createResponse()
+    {
+        ICoalesceResponseType<List<ICoalesceResponseType<CoalesceEntity>>> response = new CoalesceResponseType<>();
+        response.setResult(new ArrayList<>());
+        return response;
+    }
+
+    @Override
+    protected ICoalesceResponseType<CoalesceEntity> createResults()
+    {
+        return new CoalesceResponseType<>();
+    }
+}

--- a/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/jobs/UpdateDataObjectJob.java
+++ b/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/jobs/UpdateDataObjectJob.java
@@ -1,0 +1,67 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.services.crud.service.data.controllers.jobs;
+
+import com.incadencecorp.coalesce.framework.CoalesceFramework;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.framework.tasks.AbstractTask;
+import com.incadencecorp.coalesce.services.api.common.ResultsType;
+import com.incadencecorp.coalesce.services.api.common.StringResponse;
+import com.incadencecorp.coalesce.services.common.jobs.AbstractServiceJob;
+import com.incadencecorp.coalesce.services.crud.service.data.controllers.tasks.UpdateDataObjectTask;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class UpdateDataObjectJob
+        extends AbstractServiceJob<CoalesceRequest<CoalesceEntity[]>, StringResponse, ResultsType, CoalesceFramework> {
+
+    public UpdateDataObjectJob(CoalesceRequest<CoalesceEntity[]> request)
+    {
+        super(request);
+    }
+
+    @Override
+    protected Collection<AbstractTask<?, ResultsType, CoalesceFramework>> getTasks(CoalesceRequest<CoalesceEntity[]> request)
+    {
+        List<AbstractTask<?, ResultsType, CoalesceFramework>> tasks = new ArrayList<>();
+        for (CoalesceEntity entity : request.getParams())
+        {
+            UpdateDataObjectTask task = new UpdateDataObjectTask();
+            task.setParams(new CoalesceEntity[] { entity });
+
+            tasks.add(task);
+        }
+
+        return tasks;
+    }
+
+    @Override
+    protected StringResponse createResponse()
+    {
+        return new StringResponse();
+    }
+
+    @Override
+    protected ResultsType createResults()
+    {
+        return new ResultsType();
+    }
+}

--- a/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/jobs/UpdateDataObjectLinkagesJob.java
+++ b/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/jobs/UpdateDataObjectLinkagesJob.java
@@ -1,0 +1,195 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.services.crud.service.data.controllers.jobs;
+
+import com.incadencecorp.coalesce.api.CoalesceErrors;
+import com.incadencecorp.coalesce.common.exceptions.CoalesceException;
+import com.incadencecorp.coalesce.framework.CoalesceFramework;
+import com.incadencecorp.coalesce.framework.tasks.AbstractTask;
+import com.incadencecorp.coalesce.services.api.common.ResultsType;
+import com.incadencecorp.coalesce.services.api.common.StringResponse;
+import com.incadencecorp.coalesce.services.api.crud.DataObjectLinkRequest;
+import com.incadencecorp.coalesce.services.api.crud.DataObjectLinkType;
+import com.incadencecorp.coalesce.services.common.jobs.AbstractFrameworkServiceJob;
+import com.incadencecorp.coalesce.services.crud.service.data.controllers.tasks.UpdateDataObjectLinkagesTask;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+public class UpdateDataObjectLinkagesJob
+        extends AbstractFrameworkServiceJob<DataObjectLinkRequest, StringResponse, ResultsType> {
+
+    public UpdateDataObjectLinkagesJob(DataObjectLinkRequest request)
+    {
+        super(request);
+    }
+
+    @Override
+    protected Collection<AbstractTask<?, ResultsType, CoalesceFramework>> getTasks(DataObjectLinkRequest params)
+            throws CoalesceException
+    {
+        List<AbstractTask<?, ResultsType, CoalesceFramework>> tasks = new ArrayList<>();
+
+        for (DataObjectLinkBucket bucket : groupIntoBuckets(params.getLinkagelist()))
+        {
+            UpdateDataObjectLinkagesTask task = new UpdateDataObjectLinkagesTask();
+            task.setParams(bucket.getItems());
+
+            tasks.add(task);
+        }
+
+        return tasks;
+    }
+
+    @Override
+    protected StringResponse createResponse()
+    {
+        return new StringResponse();
+    }
+
+    @Override
+    protected ResultsType createResults()
+    {
+        return new ResultsType();
+    }
+
+    /**
+     * Groups the linkage tasks that share keys into common buckets. This solves
+     * two issues: (1) Performance have to load / save the same object multiple
+     * time for different linkage task, (2) Read - Modify - Write conflicts
+     * between treads. The second issue also has be handled by locking or
+     * Optimistic Concurrency (OCC) at a lower level but this will prevent a
+     * single request from a user from conflicting.
+     */
+    private List<DataObjectLinkBucket> groupIntoBuckets(List<DataObjectLinkType> linkages) throws CoalesceException
+    {
+
+        List<DataObjectLinkBucket> buckets = new ArrayList<>();
+        DataObjectLinkBucket container;
+
+        // Create Tasks
+        for (DataObjectLinkType linkage : linkages)
+        {
+
+            // Action Specified by Client?
+            if (linkage.getAction() == null)
+            {
+                throw new CoalesceException(String.format(CoalesceErrors.NOT_SPECIFIED, "Link Action"));
+            }
+
+            // Reset
+            container = null;
+
+            // Iterate Existing Buckets
+            for (DataObjectLinkBucket bucket : buckets)
+            {
+
+                // Belongs?
+                if (bucket.contains(linkage))
+                {
+
+                    // Already Has Bucket?
+                    if (container != null)
+                    {
+
+                        // Yes; Combine Buckets
+                        container.combine(bucket);
+
+                    }
+                    else
+                    {
+
+                        // No; Add to Existing Bucket
+                        container = bucket;
+
+                        container.add(linkage);
+
+                    }
+                }
+            }
+
+            // Added to Bucket?
+            if (container == null)
+            {
+                // No; Create New Bucket
+                buckets.add(new DataObjectLinkBucket(linkage));
+            }
+        }
+
+        return buckets;
+
+    }
+
+    /*--------------------------------------------------------------------------
+    Private Classes
+    --------------------------------------------------------------------------*/
+
+    private static class DataObjectLinkBucket {
+
+        private HashSet<String> keys;
+        private List<DataObjectLinkType> linkages;
+
+        /**
+         * Creates a new bucket containing the linkage.
+         */
+        private DataObjectLinkBucket(DataObjectLinkType linkage)
+        {
+
+            keys = new HashSet<>();
+            linkages = new ArrayList<>();
+
+            add(linkage);
+
+        }
+
+        private boolean contains(DataObjectLinkType linkage)
+        {
+
+            return keys.contains(linkage.getDataObjectKeySource()) || keys.contains(linkage.getDataObjectKeyTarget());
+
+        }
+
+        private void add(DataObjectLinkType linkage)
+        {
+
+            keys.add(linkage.getDataObjectKeySource());
+            keys.add(linkage.getDataObjectKeyTarget());
+
+            linkages.add(linkage);
+
+        }
+
+        private void combine(DataObjectLinkBucket bucket)
+        {
+            keys.addAll(bucket.keys);
+            linkages.addAll(bucket.linkages);
+
+            bucket.linkages.clear();
+            bucket.keys.clear();
+        }
+
+        private DataObjectLinkType[] getItems()
+        {
+            return linkages.toArray(new DataObjectLinkType[0]);
+        }
+
+    }
+}

--- a/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/jobs/UpdateDataObjectStatusJob.java
+++ b/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/jobs/UpdateDataObjectStatusJob.java
@@ -1,0 +1,90 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.services.crud.service.data.controllers.jobs;
+
+import com.incadencecorp.coalesce.api.CoalesceParameters;
+import com.incadencecorp.coalesce.common.helpers.ArrayHelper;
+import com.incadencecorp.coalesce.framework.CoalesceFramework;
+import com.incadencecorp.coalesce.framework.tasks.AbstractTask;
+import com.incadencecorp.coalesce.services.api.common.ResultsType;
+import com.incadencecorp.coalesce.services.api.common.StringResponse;
+import com.incadencecorp.coalesce.services.api.crud.DataObjectStatusType;
+import com.incadencecorp.coalesce.services.api.crud.DataObjectUpdateStatusRequest;
+import com.incadencecorp.coalesce.services.common.jobs.AbstractFrameworkServiceJob;
+import com.incadencecorp.coalesce.services.crud.service.data.controllers.tasks.UpdateDataObjectStatusTask;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class UpdateDataObjectStatusJob
+        extends AbstractFrameworkServiceJob<DataObjectUpdateStatusRequest, StringResponse, ResultsType> {
+
+    private static final int DEFAULT_BLOCK_SIZE = 100;
+    private int blockSize = DEFAULT_BLOCK_SIZE;
+
+    public UpdateDataObjectStatusJob(DataObjectUpdateStatusRequest request)
+    {
+        super(request);
+    }
+
+    @Override
+    public void setProperties(Map<String, String> params)
+    {
+        super.setProperties(params);
+
+        if (params.containsKey(CoalesceParameters.PARAM_BLOCK_SIZE))
+        {
+            blockSize = Integer.parseInt(params.get(CoalesceParameters.PARAM_BLOCK_SIZE));
+        }
+    }
+
+    @Override
+    protected Collection<AbstractTask<?, ResultsType, CoalesceFramework>> getTasks(DataObjectUpdateStatusRequest params)
+    {
+        List<AbstractTask<?, ResultsType, CoalesceFramework>> tasks = new ArrayList<>();
+
+        DataObjectStatusType[][] chunks = ArrayHelper.createChunks(params.getTaskList().toArray(new DataObjectStatusType[0]),
+                                                                   blockSize,
+                                                                   DataObjectStatusType[][]::new);
+
+        for (DataObjectStatusType[] chunk : chunks)
+        {
+            UpdateDataObjectStatusTask task = new UpdateDataObjectStatusTask();
+            task.setParams(chunk);
+
+            tasks.add(task);
+        }
+
+        return tasks;
+    }
+
+    @Override
+    protected StringResponse createResponse()
+    {
+        return new StringResponse();
+    }
+
+    @Override
+    protected ResultsType createResults()
+    {
+        return new ResultsType();
+    }
+}

--- a/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/tasks/CreateDataObjectTask.java
+++ b/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/tasks/CreateDataObjectTask.java
@@ -1,0 +1,108 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.services.crud.service.data.controllers.tasks;
+
+import com.incadencecorp.coalesce.api.EResultStatus;
+import com.incadencecorp.coalesce.api.ICoalesceResponseType;
+import com.incadencecorp.coalesce.common.exceptions.CoalesceException;
+import com.incadencecorp.coalesce.enums.ECrudOperations;
+import com.incadencecorp.coalesce.framework.CoalesceFramework;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.framework.tasks.AbstractFrameworkTask;
+import com.incadencecorp.coalesce.framework.tasks.TaskParameters;
+import com.incadencecorp.coalesce.framework.util.CoalesceNotifierUtil;
+import com.incadencecorp.coalesce.framework.validation.CoalesceValidator;
+import com.incadencecorp.coalesce.services.api.common.ResultsType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class CreateDataObjectTask extends AbstractFrameworkTask<CoalesceEntity[], ResultsType> {
+
+    @Override
+    protected ResultsType doWork(TaskParameters<CoalesceFramework, CoalesceEntity[]> parameters) throws CoalesceException
+    {
+        ResultsType result = new ResultsType();
+        CoalesceFramework framework = parameters.getTarget();
+        CoalesceEntity[] entities = parameters.getParams();
+        CoalesceValidator validator = new CoalesceValidator();
+
+        for (CoalesceEntity entity : entities)
+        {
+            // TODO This breaks the SOAP Persister Impl Tests
+            //entity.getLinkageSection().clearLinkages();
+            entity.setModifiedBy(parameters.getPrincipalName());
+            entity.setModifiedByIP(parameters.getPrincipalIp());
+
+            Map<String, String> results = new HashMap<>();
+            // TODO validator.validate(parameters.getPrincipal(), entity,
+            // CoalesceConstraintCache.getCoalesceConstraints(entity));
+
+            // TODO Check to see if entity exists first.
+
+            if (!results.isEmpty())
+            {
+                result.setStatus(EResultStatus.FAILED);
+                // TODO Create a more meaningful error message
+                result.setError("Validation Failed");
+                break;
+            }
+        }
+
+        if (result.getStatus() != EResultStatus.FAILED && framework.saveCoalesceEntity(entities))
+        {
+            result.setStatus(EResultStatus.SUCCESS);
+
+            CoalesceNotifierUtil.sendCrud(getName(), ECrudOperations.CREATE, entities);
+        }
+        else
+        {
+            result.setStatus(EResultStatus.FAILED);
+        }
+
+        return result;
+    }
+
+    @Override
+    protected Map<String, String> getParameters(CoalesceEntity[] entities, boolean isTrace)
+    {
+        Map<String, String> results = new HashMap<>();
+
+        for (CoalesceEntity entity : entities)
+        {
+            if (isTrace)
+            {
+                results.put(entity.getKey(), entity.toXml());
+            }
+            else
+            {
+                results.put(entity.getKey(), entity.getName());
+            }
+        }
+
+        return results;
+    }
+
+    @Override
+    protected ResultsType createResult()
+    {
+        return new ResultsType();
+    }
+
+}

--- a/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/tasks/RetrieveDataObjectTask.java
+++ b/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/tasks/RetrieveDataObjectTask.java
@@ -1,0 +1,96 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.services.crud.service.data.controllers.tasks;
+
+import com.incadencecorp.coalesce.api.CoalesceErrors;
+import com.incadencecorp.coalesce.api.EResultStatus;
+import com.incadencecorp.coalesce.api.ICoalesceResponseType;
+import com.incadencecorp.coalesce.common.exceptions.CoalesceException;
+import com.incadencecorp.coalesce.enums.ECrudOperations;
+import com.incadencecorp.coalesce.framework.CoalesceFramework;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceIteratorGetVersion;
+import com.incadencecorp.coalesce.framework.jobs.responses.CoalesceResponseType;
+import com.incadencecorp.coalesce.framework.tasks.AbstractFrameworkTask;
+import com.incadencecorp.coalesce.framework.tasks.TaskParameters;
+import com.incadencecorp.coalesce.framework.util.CoalesceNotifierUtil;
+import com.incadencecorp.coalesce.services.api.crud.DataObjectKeyType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RetrieveDataObjectTask
+        extends AbstractFrameworkTask<DataObjectKeyType[], ICoalesceResponseType<CoalesceEntity>> {
+
+    @Override
+    protected ICoalesceResponseType<CoalesceEntity> doWork(TaskParameters<CoalesceFramework, DataObjectKeyType[]> parameters)
+            throws CoalesceException
+    {
+        ICoalesceResponseType<CoalesceEntity> result = createResult();
+        CoalesceIteratorGetVersion it = new CoalesceIteratorGetVersion();
+        CoalesceFramework framework = parameters.getTarget();
+        DataObjectKeyType[] params = parameters.getParams();
+
+        for (DataObjectKeyType task : params)
+        {
+            CoalesceEntity entity = framework.getCoalesceEntity(task.getKey());
+
+            if (task.getVer() == -1)
+            {
+                task.setVer(entity.getObjectVersion());
+            }
+
+            if (entity.isValidObjectVersion(task.getVer()))
+            {
+                it.getVersion(entity, task.getVer());
+                result.setStatus(EResultStatus.SUCCESS);
+                result.setResult(entity);
+
+                CoalesceNotifierUtil.sendCrud(getName(), ECrudOperations.READ, entity);
+            }
+            else
+            {
+                result.setStatus(EResultStatus.FAILED);
+                result.setError(String.format(CoalesceErrors.INVALID_OBJECT_VERSION, task.getVer(), task.getKey()));
+            }
+        }
+
+        return result;
+    }
+
+    @Override
+    protected Map<String, String> getParameters(DataObjectKeyType[] params, boolean isTrace)
+    {
+        Map<String, String> results = new HashMap<>();
+
+        for (DataObjectKeyType type : params)
+        {
+            results.put(type.getKey(), Integer.toString(type.getVer()));
+        }
+
+        return results;
+    }
+
+    @Override
+    protected ICoalesceResponseType<CoalesceEntity> createResult()
+    {
+        return new CoalesceResponseType<>();
+    }
+
+}

--- a/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/tasks/UpdateDataObjectLinkagesTask.java
+++ b/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/tasks/UpdateDataObjectLinkagesTask.java
@@ -1,0 +1,191 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.services.crud.service.data.controllers.tasks;
+
+import com.incadencecorp.coalesce.api.EResultStatus;
+import com.incadencecorp.coalesce.common.exceptions.CoalesceException;
+import com.incadencecorp.coalesce.common.helpers.EntityLinkHelper;
+import com.incadencecorp.coalesce.enums.ECrudOperations;
+import com.incadencecorp.coalesce.framework.CoalesceFramework;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.framework.datamodel.ECoalesceObjectStatus;
+import com.incadencecorp.coalesce.framework.tasks.AbstractFrameworkTask;
+import com.incadencecorp.coalesce.framework.tasks.TaskParameters;
+import com.incadencecorp.coalesce.framework.util.CoalesceNotifierUtil;
+import com.incadencecorp.coalesce.services.api.common.ResultsType;
+import com.incadencecorp.coalesce.services.api.crud.DataObjectLinkType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class UpdateDataObjectLinkagesTask extends AbstractFrameworkTask<DataObjectLinkType[], ResultsType> {
+
+    @Override
+    protected ResultsType doWork(TaskParameters<CoalesceFramework, DataObjectLinkType[]> parameters) throws CoalesceException
+    {
+        ResultsType result = new ResultsType();
+        CoalesceFramework framework = parameters.getTarget();
+        DataObjectLinkType[] params = parameters.getParams();
+
+        String user = parameters.getPrincipalName();
+        String ip = parameters.getPrincipalIp();
+
+        // TODO Implement Authorization
+        // boolean isSysAdmin = UserValidator.isSysAdmin(userId);
+        boolean isSysAdmin = true;
+
+        Map<String, CoalesceEntity> map = new HashMap<>();
+
+        // Determine complete list of keys
+        for (DataObjectLinkType task : params)
+        {
+            // Same Source & Target?
+            if (task.getDataObjectKeySource().equalsIgnoreCase(task.getDataObjectKeyTarget()))
+            {
+                throw new CoalesceException("Linking an object to itself is not allowed");
+            }
+
+            map.put(task.getDataObjectKeySource(), null);
+            map.put(task.getDataObjectKeyTarget(), null);
+        }
+
+        // Retrieve Entities
+        CoalesceEntity[] entities = framework.getCoalesceEntities(map.keySet().toArray(new String[0]));
+
+        // Update Map with Entity
+        for (CoalesceEntity entity : entities)
+        {
+            map.put(entity.getKey(), entity);
+        }
+
+        // Link Objects
+        for (DataObjectLinkType task : params)
+        {
+            CoalesceEntity entity1 = map.get(task.getDataObjectKeySource());
+            CoalesceEntity entity2 = map.get(task.getDataObjectKeyTarget());
+
+            switch (task.getAction())
+            {
+            case MAKEREADONLY:
+                EntityLinkHelper.linkEntitiesUniDirectional(entity1,
+                                              task.getLinkType(),
+                                              entity2,
+                                              user,
+                                              ip,
+                                              task.getLabel(),
+                                              true,
+                                              ECoalesceObjectStatus.READONLY,
+                                              isSysAdmin);
+                break;
+            case LINK:
+
+                EntityLinkHelper.linkEntitiesUniDirectional(entity1,
+                                              task.getLinkType(),
+                                              entity2,
+                                              user,
+                                              ip,
+                                              task.getLabel(),
+                                              true,
+                                              ECoalesceObjectStatus.ACTIVE,
+                                              isSysAdmin);
+                break;
+            case UNLINK:
+                EntityLinkHelper.unLinkEntities(entity1, entity2, task.getLinkType(), user, ip, isSysAdmin);
+                break;
+            }
+
+        }
+
+        // Save Objects
+        if (framework.saveCoalesceEntity(entities))
+        {
+            result.setStatus(EResultStatus.SUCCESS);
+
+            // Send Notifications
+            for (DataObjectLinkType task : params)
+            {
+                CoalesceEntity entity1 = map.get(task.getDataObjectKeySource());
+                CoalesceEntity entity2 = map.get(task.getDataObjectKeyTarget());
+
+                switch (task.getAction())
+                {
+                case MAKEREADONLY:
+                    CoalesceNotifierUtil.sendLinkage(getName(),
+                                                     ECrudOperations.UPDATE,
+                                                     entity1,
+                                                     task.getLinkType(),
+                                                     entity2);
+                    break;
+                case LINK:
+                    CoalesceNotifierUtil.sendLinkage(getName(),
+                                                     ECrudOperations.CREATE,
+                                                     entity1,
+                                                     task.getLinkType(),
+                                                     entity2);
+                    break;
+                case UNLINK:
+                    CoalesceNotifierUtil.sendLinkage(getName(),
+                                                     ECrudOperations.DELETE,
+                                                     entity1,
+                                                     task.getLinkType(),
+                                                     entity2);
+                    break;
+                }
+
+            }
+        }
+        else
+        {
+            result.setStatus(EResultStatus.FAILED);
+        }
+
+        // TODO Since UpdateLinkageTask no longer always processes a single
+        // task there is no longer a one to one relationship to what the
+        // user requested and the result set they gets back. This means if
+        // one of the task fails its impossible to determine what linkages
+        // were involved in that task. This will need to be refactored to
+        // return a list of results ( 1 / Linkage processed).
+
+        return result;
+    }
+
+    @Override
+    protected Map<String, String> getParameters(DataObjectLinkType[] params, boolean isTrace)
+    {
+        Map<String, String> results = new HashMap<>();
+
+        for (DataObjectLinkType type : params)
+        {
+            results.put("source", type.getDataObjectKeySource());
+            results.put("target", type.getDataObjectKeyTarget());
+            results.put("label", type.getLabel());
+            results.put("action", type.getAction().toString());
+            results.put("link type", type.getLinkType() != null ? type.getLinkType().toString() : "");
+        }
+
+        return results;
+    }
+
+    @Override
+    protected ResultsType createResult()
+    {
+        return new ResultsType();
+    }
+
+}

--- a/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/tasks/UpdateDataObjectStatusTask.java
+++ b/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/tasks/UpdateDataObjectStatusTask.java
@@ -1,0 +1,116 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.services.crud.service.data.controllers.tasks;
+
+import com.incadencecorp.coalesce.api.CoalesceErrors;
+import com.incadencecorp.coalesce.api.EResultStatus;
+import com.incadencecorp.coalesce.common.exceptions.CoalesceException;
+import com.incadencecorp.coalesce.enums.ECrudOperations;
+import com.incadencecorp.coalesce.framework.CoalesceFramework;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.framework.datamodel.ECoalesceObjectStatus;
+import com.incadencecorp.coalesce.framework.tasks.AbstractFrameworkTask;
+import com.incadencecorp.coalesce.framework.tasks.TaskParameters;
+import com.incadencecorp.coalesce.framework.util.CoalesceNotifierUtil;
+import com.incadencecorp.coalesce.services.api.common.ResultsType;
+import com.incadencecorp.coalesce.services.api.crud.DataObjectStatusType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class UpdateDataObjectStatusTask extends AbstractFrameworkTask<DataObjectStatusType[], ResultsType> {
+
+    @Override
+    protected ResultsType doWork(TaskParameters<CoalesceFramework, DataObjectStatusType[]> parameters)
+            throws CoalesceException
+    {
+        ResultsType result = new ResultsType();
+
+        Map<String, CoalesceEntity> entities = new HashMap<>();
+        CoalesceFramework framework = parameters.getTarget();
+
+        // Create PlaceHolders
+        for (DataObjectStatusType task : parameters.getParams())
+        {
+            entities.put(task.getKey(), new CoalesceEntity());
+        }
+
+        // Retrieve Entities
+        for (CoalesceEntity entity : framework.getCoalesceEntities(entities.keySet().toArray(new String[0])))
+        {
+            entities.put(entity.getKey(), entity);
+        }
+
+        // Update Entities
+        for (DataObjectStatusType task : parameters.getParams())
+        {
+            if (task.getAction() == null)
+            {
+                throw new CoalesceException(String.format(CoalesceErrors.NOT_SPECIFIED, "Update Action"));
+            }
+
+            CoalesceEntity entity = entities.get(task.getKey());
+
+            if (entity.isInitialized())
+            {
+                switch (task.getAction())
+                {
+                case MARK_AS_ACTIVE:
+                    entity.setStatus(ECoalesceObjectStatus.ACTIVE);
+                    break;
+                case MARK_AS_DELETED:
+                    entity.setStatus(ECoalesceObjectStatus.DELETED);
+                    break;
+                case MARK_AS_READONLY:
+                    entity.setStatus(ECoalesceObjectStatus.READONLY);
+                    break;
+                }
+            }
+        }
+
+        CoalesceEntity[] entitiesUpdated = entities.values().stream().filter(CoalesceEntity::isInitialized).toArray(
+                CoalesceEntity[]::new);
+
+        if (framework.saveCoalesceEntity(entitiesUpdated))
+        {
+            result.setStatus(EResultStatus.SUCCESS);
+
+            CoalesceNotifierUtil.sendCrud(getName(), ECrudOperations.UPDATE, entitiesUpdated);
+        }
+        else
+        {
+            result.setStatus(EResultStatus.FAILED);
+        }
+
+        return result;
+    }
+
+    @Override
+    protected Map<String, String> getParameters(DataObjectStatusType[] params, boolean isTrace)
+    {
+        return new HashMap<>();
+    }
+
+    @Override
+    protected ResultsType createResult()
+    {
+        return new ResultsType();
+    }
+
+}

--- a/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/tasks/UpdateDataObjectTask.java
+++ b/src/Coalesce.Services/CRUD/service-data/src/main/java/com/incadencecorp/coalesce/services/crud/service/data/controllers/tasks/UpdateDataObjectTask.java
@@ -1,0 +1,102 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.services.crud.service.data.controllers.tasks;
+
+import com.incadencecorp.coalesce.api.EResultStatus;
+import com.incadencecorp.coalesce.common.exceptions.CoalesceException;
+import com.incadencecorp.coalesce.enums.ECrudOperations;
+import com.incadencecorp.coalesce.framework.CoalesceFramework;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceIteratorMerge;
+import com.incadencecorp.coalesce.framework.tasks.AbstractFrameworkTask;
+import com.incadencecorp.coalesce.framework.tasks.TaskParameters;
+import com.incadencecorp.coalesce.framework.util.CoalesceNotifierUtil;
+import com.incadencecorp.coalesce.framework.validation.CoalesceValidator;
+import com.incadencecorp.coalesce.services.api.common.ResultsType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class UpdateDataObjectTask extends AbstractFrameworkTask<CoalesceEntity[], ResultsType> {
+
+    @Override
+    protected ResultsType doWork(TaskParameters<CoalesceFramework, CoalesceEntity[]> parameters) throws CoalesceException
+    {
+        ResultsType result = new ResultsType();
+        CoalesceFramework framework = parameters.getTarget();
+        CoalesceValidator validator = new CoalesceValidator();
+        CoalesceEntity[] entities = parameters.getParams();
+
+        List<CoalesceEntity> entitiesToSave = new ArrayList<>();
+
+        for (CoalesceEntity updated : entities)
+        {
+            // TODO Implement Bulk Retrieve
+            CoalesceEntity original = framework.getCoalesceEntity(updated.getKey());
+
+            if (!original.isReadOnly())
+            {
+                CoalesceIteratorMerge merger = new CoalesceIteratorMerge();
+
+                // TODO Add this back?
+                //updated.pruneCoalesceObject(updated.getLinkageSection());
+                entitiesToSave.add(merger.merge(parameters.getPrincipalName(), parameters.getPrincipalIp(), original, updated));
+
+                // TODO Enable this
+                Map<String, String> results = new HashMap<>();
+                // validator.validate(extra.getPrincipal(), entity,
+                // CoalesceConstraintCache.getCoalesceConstraints(entity));
+
+                if (!results.isEmpty())
+                {
+                    result.setStatus(EResultStatus.FAILED);
+                    break;
+                }
+            }
+        }
+
+        if (result.getStatus() != EResultStatus.FAILED && framework.saveCoalesceEntity(entitiesToSave.toArray(new CoalesceEntity[0])))
+        {
+            result.setStatus(EResultStatus.SUCCESS);
+
+            CoalesceNotifierUtil.sendCrud(getName(), ECrudOperations.UPDATE, entities);
+        }
+        else
+        {
+            result.setStatus(EResultStatus.FAILED);
+        }
+
+        return result;
+    }
+
+    @Override
+    protected Map<String, String> getParameters(CoalesceEntity[] params, boolean isTrace)
+    {
+        return new HashMap<>();
+    }
+
+    @Override
+    protected ResultsType createResult()
+    {
+        return new ResultsType();
+    }
+
+}

--- a/src/Coalesce.Services/CRUD/service-data/src/test/java/com/incadencecorp/coalesce/services/crud/service/rest/LinkageDataControllerTest.java
+++ b/src/Coalesce.Services/CRUD/service-data/src/test/java/com/incadencecorp/coalesce/services/crud/service/rest/LinkageDataControllerTest.java
@@ -25,7 +25,6 @@ import com.incadencecorp.coalesce.framework.datamodel.ELinkTypes;
 import com.incadencecorp.coalesce.framework.persistance.derby.DerbyPersistor;
 import com.incadencecorp.coalesce.search.CoalesceSearchFramework;
 import com.incadencecorp.coalesce.services.common.controllers.datamodel.GraphLink;
-import com.incadencecorp.coalesce.services.crud.service.client.CrudFrameworkClientImpl;
 import com.incadencecorp.coalesce.services.crud.service.data.controllers.LinkageDataController;
 import org.junit.Assert;
 import org.junit.Test;
@@ -51,7 +50,7 @@ public class LinkageDataControllerTest {
         CoalesceSearchFramework framework = new CoalesceSearchFramework();
         framework.setAuthoritativePersistor(new DerbyPersistor());
 
-        LinkageDataController controller = new LinkageDataController(new CrudFrameworkClientImpl(framework), framework);
+        LinkageDataController controller = new LinkageDataController(framework);
 
         // Create Entities
         CoalesceEntity entity1 = CoalesceEntity.create("name", "source", "1.0");
@@ -94,7 +93,7 @@ public class LinkageDataControllerTest {
         CoalesceSearchFramework framework = new CoalesceSearchFramework();
         framework.setAuthoritativePersistor(new DerbyPersistor());
 
-        LinkageDataController controller = new LinkageDataController(new CrudFrameworkClientImpl(framework), framework);
+        LinkageDataController controller = new LinkageDataController(framework);
 
         // Create Entities
         CoalesceEntity entity1 = CoalesceEntity.create("name", "source", "1.0");
@@ -165,14 +164,14 @@ public class LinkageDataControllerTest {
     /**
      * This test ensures that not specifying a linkage type will result in an exception
      */
-    @Test (expected = RemoteException.class)
+    @Test(expected = RemoteException.class)
     public void testTypeNotSet() throws Exception
     {
         // Setup
         CoalesceSearchFramework framework = new CoalesceSearchFramework();
         framework.setAuthoritativePersistor(new DerbyPersistor());
 
-        LinkageDataController controller = new LinkageDataController(new CrudFrameworkClientImpl(framework), framework);
+        LinkageDataController controller = new LinkageDataController(framework);
 
         // Create Task
         GraphLink task = new GraphLink();

--- a/src/Coalesce.Services/CRUD/service/src/main/java/com/incadencecorp/coalesce/services/crud/service/tasks/RetrieveDataObjectTask.java
+++ b/src/Coalesce.Services/CRUD/service/src/main/java/com/incadencecorp/coalesce/services/crud/service/tasks/RetrieveDataObjectTask.java
@@ -65,8 +65,6 @@ public class RetrieveDataObjectTask extends AbstractFrameworkTask<DataObjectKeyT
                 result.setStatus(EResultStatus.FAILED);
                 result.setError(String.format(CoalesceErrors.INVALID_OBJECT_VERSION, task.getVer(), task.getKey()));
             }
-
-            result.setStatus(EResultStatus.SUCCESS);
         }
 
         return result;

--- a/src/Coalesce.Services/Common/src/main/java/com/incadencecorp/coalesce/services/common/CoalesceRemoteException.java
+++ b/src/Coalesce.Services/Common/src/main/java/com/incadencecorp/coalesce/services/common/CoalesceRemoteException.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.services.common;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.rmi.RemoteException;
+
+/**
+ * @author Derek Clemenzi
+ */
+public class CoalesceRemoteException extends RemoteException {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CoalesceRemoteException.class);
+
+    public CoalesceRemoteException(String error)
+    {
+        super(error);
+    }
+
+    public CoalesceRemoteException(String error, Exception e)
+    {
+        super(error, e);
+
+        if (e == null)
+        {
+            LOGGER.warn(error);
+        }
+        else
+        {
+            LOGGER.error(error, e);
+        }
+    }
+
+}

--- a/src/Coalesce.Services/Search/service-data/src/main/java/com/incadencecorp/coalesce/services/search/service/data/controllers/TemplateDataController.java
+++ b/src/Coalesce.Services/Search/service-data/src/main/java/com/incadencecorp/coalesce/services/search/service/data/controllers/TemplateDataController.java
@@ -206,7 +206,9 @@ public class TemplateDataController {
             results.add(getField(CoalescePropertyFactory.getName(), ECoalesceFieldDataTypes.STRING_TYPE));
             results.add(getField(CoalescePropertyFactory.getSource(), ECoalesceFieldDataTypes.STRING_TYPE));
             results.add(getField(CoalescePropertyFactory.getDateCreated(), ECoalesceFieldDataTypes.DATE_TIME_TYPE));
+            results.add(getField(CoalescePropertyFactory.getCreatedBy(), ECoalesceFieldDataTypes.STRING_TYPE));
             results.add(getField(CoalescePropertyFactory.getLastModified(), ECoalesceFieldDataTypes.DATE_TIME_TYPE));
+            results.add(getField(CoalescePropertyFactory.getLastModifiedBy(), ECoalesceFieldDataTypes.STRING_TYPE));
             results.add(getField(CoalescePropertyFactory.getEntityStatus(), ECoalesceFieldDataTypes.ENUMERATION_TYPE));
             results.add(getField(CoalescePropertyFactory.getEntityId(), ECoalesceFieldDataTypes.STRING_TYPE));
         }

--- a/src/Coalesce.Services/Search/service-data/src/main/java/com/incadencecorp/coalesce/services/search/service/data/controllers/TemplateDataController.java
+++ b/src/Coalesce.Services/Search/service-data/src/main/java/com/incadencecorp/coalesce/services/search/service/data/controllers/TemplateDataController.java
@@ -29,6 +29,7 @@ import com.incadencecorp.coalesce.framework.datamodel.CoalesceRecordset;
 import com.incadencecorp.coalesce.framework.datamodel.CoalesceSection;
 import com.incadencecorp.coalesce.framework.datamodel.ECoalesceFieldDataTypes;
 import com.incadencecorp.coalesce.framework.persistance.ObjectMetaData;
+import com.incadencecorp.coalesce.framework.util.CoalesceTemplateUtil;
 import com.incadencecorp.coalesce.search.factory.CoalescePropertyFactory;
 import com.incadencecorp.coalesce.services.search.service.data.model.CoalesceObjectImpl;
 import com.incadencecorp.coalesce.services.search.service.data.model.FieldData;
@@ -476,6 +477,8 @@ public class TemplateDataController {
             LOGGER.info("Saving template {}, Key: {}", template.getName(), template.getKey());
             framework.saveCoalesceEntityTemplate(template);
             templates.put(template.getKey(), new TemplateNode(template));
+
+            CoalesceTemplateUtil.addTemplates(template);
 
             result = template.getKey();
         }

--- a/src/Coalesce.Services/Search/service-data/src/test/java/com/incadencecorp/coalesce/services/search/service/rest/TemplateDataControllerTest.java
+++ b/src/Coalesce.Services/Search/service-data/src/test/java/com/incadencecorp/coalesce/services/search/service/rest/TemplateDataControllerTest.java
@@ -157,14 +157,22 @@ public class TemplateDataControllerTest {
         Assert.assertEquals(CoalesceEntity.ATTRIBUTE_NAME, fieldResults.get(2).getName());
         Assert.assertEquals(CoalesceEntity.ATTRIBUTE_SOURCE, fieldResults.get(3).getName());
         Assert.assertEquals(CoalesceEntity.ATTRIBUTE_DATECREATED, fieldResults.get(4).getName());
-        Assert.assertEquals(CoalesceEntity.ATTRIBUTE_LASTMODIFIED, fieldResults.get(5).getName());
+        Assert.assertEquals("creator", fieldResults.get(5).getName());
+        Assert.assertEquals(CoalesceEntity.ATTRIBUTE_LASTMODIFIED, fieldResults.get(6).getName());
+        Assert.assertEquals(CoalesceEntity.ATTRIBUTE_MODIFIEDBY, fieldResults.get(7).getName());
+        Assert.assertEquals(CoalesceEntity.ATTRIBUTE_STATUS, fieldResults.get(8).getName());
+        Assert.assertEquals(CoalesceEntity.ATTRIBUTE_ENTITYID, fieldResults.get(9).getName());
 
         Assert.assertEquals(ECoalesceFieldDataTypes.GUID_TYPE, fieldResults.get(0).getDataType());
         Assert.assertEquals(ECoalesceFieldDataTypes.STRING_TYPE, fieldResults.get(1).getDataType());
         Assert.assertEquals(ECoalesceFieldDataTypes.STRING_TYPE, fieldResults.get(2).getDataType());
         Assert.assertEquals(ECoalesceFieldDataTypes.STRING_TYPE, fieldResults.get(3).getDataType());
         Assert.assertEquals(ECoalesceFieldDataTypes.DATE_TIME_TYPE, fieldResults.get(4).getDataType());
-        Assert.assertEquals(ECoalesceFieldDataTypes.DATE_TIME_TYPE, fieldResults.get(5).getDataType());
+        Assert.assertEquals(ECoalesceFieldDataTypes.STRING_TYPE, fieldResults.get(5).getDataType());
+        Assert.assertEquals(ECoalesceFieldDataTypes.DATE_TIME_TYPE, fieldResults.get(6).getDataType());
+        Assert.assertEquals(ECoalesceFieldDataTypes.STRING_TYPE, fieldResults.get(7).getDataType());
+        Assert.assertEquals(ECoalesceFieldDataTypes.ENUMERATION_TYPE, fieldResults.get(8).getDataType());
+        Assert.assertEquals(ECoalesceFieldDataTypes.STRING_TYPE, fieldResults.get(9).getDataType());
 
         fieldResults = controller.getRecordSetFields(template.getKey(), results.get(1).getKey());
 

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/api/CoalesceSimplePrincipal.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/api/CoalesceSimplePrincipal.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2017 - InCadence Strategic Solutions Inc., All Rights Reserved
+ *
+ *  Notwithstanding any contractor copyright notice, the Government has Unlimited
+ *  Rights in this work as defined by DFARS 252.227-7013 and 252.227-7014.  Use
+ *  of this work other than as specifically authorized by these DFARS Clauses may
+ *  violate Government rights in this work.
+ *
+ *  DFARS Clause reference: 252.227-7013 (a)(16) and 252.227-7014 (a)(16)
+ *  Unlimited Rights. The Government has the right to use, modify, reproduce,
+ *  perform, display, release or disclose this computer software and to have or
+ *  authorize others to do so.
+ *
+ *  Distribution Statement D. Distribution authorized to the Department of
+ *  Defense and U.S. DoD contractors only in support of U.S. DoD efforts.
+ *
+ */
+
+package com.incadencecorp.coalesce.api;
+
+import java.security.Principal;
+
+/**
+ * @author Derek Clemenzi
+ */
+public class CoalesceSimplePrincipal implements ICoalescePrincipal {
+
+    private String ip;
+    private String name;
+
+    public CoalesceSimplePrincipal(String name)
+    {
+        this(name, "");
+    }
+
+    public CoalesceSimplePrincipal(Principal principal)
+    {
+        this(principal.getName(), "");
+    }
+
+    public CoalesceSimplePrincipal(String name, String ip)
+    {
+        if (name == null)
+        {
+            throw new IllegalArgumentException("Principal name can not be null");
+        }
+        else
+        {
+            this.name = name;
+        }
+
+        this.ip = ip;
+    }
+
+    @Override
+    public String getIp()
+    {
+        return ip;
+    }
+
+    @Override
+    public String getName()
+    {
+        return this.name;
+    }
+
+    public boolean equals(Object obj)
+    {
+        return !(obj instanceof CoalesceSimplePrincipal) ? false : this.name.equals(((CoalesceSimplePrincipal) obj).name);
+    }
+
+    public int hashCode()
+    {
+        return this.name.hashCode();
+    }
+
+    public String toString()
+    {
+        return this.name;
+    }
+}

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceEntity.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceEntity.java
@@ -87,6 +87,7 @@ public class CoalesceEntity extends CoalesceObjectHistory {
     public static final String ATTRIBUTE_UPLOADEDTOSERVER = "uploadedtoserver";
 
     private Entity _entity;
+    private String creator;
 
     // ----------------------------------------------------------------------//
     // Factory and Initialization
@@ -448,8 +449,20 @@ public class CoalesceEntity extends CoalesceObjectHistory {
      */
     public final String getCreatedBy()
     {
-        List<History> history = _entity.getHistory();
-        return history.isEmpty() ? _entity.getModifiedby() : history.get(history.size() - 1).getModifiedby();
+        if (creator == null)
+        {
+            if (getObjectVersion() == 1)
+            {
+                creator = _entity.getModifiedby();
+            }
+            else
+            {
+                List<History> history = _entity.getHistory();
+                creator = history.isEmpty() ? null : history.get(history.size() - 1).getModifiedby();
+            }
+        }
+
+        return creator;
     }
 
     /**

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceEntityTemplate.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceEntityTemplate.java
@@ -6,7 +6,11 @@ import com.incadencecorp.coalesce.common.helpers.StringHelper;
 import com.incadencecorp.coalesce.common.helpers.XmlHelper;
 import org.apache.commons.io.Charsets;
 import org.joda.time.DateTime;
-import org.w3c.dom.*;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
 import java.io.IOException;
@@ -89,9 +93,8 @@ public class CoalesceEntityTemplate implements Comparable<CoalesceEntityTemplate
      *
      * @param doc org.w3c.dom Document that will be used to create the {@link CoalesceEntityTemplate}
      * @return {@link CoalesceEntityTemplate} created from the {@link CoalesceEntity} entity's Document
-     * @throws CoalesceException on error
      */
-    public static CoalesceEntityTemplate create(Document doc) throws CoalesceException
+    public static CoalesceEntityTemplate create(Document doc)
     {
         // Create a new CoalesceEntityTemplate
         CoalesceEntityTemplate entTemp = new CoalesceEntityTemplate();
@@ -205,12 +208,22 @@ public class CoalesceEntityTemplate implements Comparable<CoalesceEntityTemplate
 
         if (StringHelper.isNullOrEmpty(result))
         {
-            result = UUID.nameUUIDFromBytes((getName() + getSource() + getVersion()).getBytes(Charsets.UTF_8)).toString();
+            result = getHashedKey();
             setKey(result);
 
         }
 
         return result;
+    }
+
+    public String getHashedKey()
+    {
+        return getHashedKey(getName(), getSource(), getVersion());
+    }
+
+    public static String getHashedKey(String name, String source, String version)
+    {
+        return UUID.nameUUIDFromBytes((name + source + version).getBytes(Charsets.UTF_8)).toString();
     }
 
     /**

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceIteratorGetVersion.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceIteratorGetVersion.java
@@ -83,6 +83,9 @@ public class CoalesceIteratorGetVersion extends CoalesceIterator {
             throw new IllegalArgumentException("Invalid Version");
         }
 
+        // Set internal creator variable before pruning history
+        entity.getCreatedBy();
+
         processAllElements(entity);
 
         entity.setObjectVersion(version);

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceRecord.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceRecord.java
@@ -96,6 +96,7 @@ public class CoalesceRecord extends CoalesceObjectHistory {
         }
 
         newRecord.setName(name);
+        newRecord.setObjectVersion(parent.getEntity().getObjectVersion());
 
         //parent.addChildCoalesceObject(newRecord);
 

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/exim/impl/JsonFullEximImpl.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/exim/impl/JsonFullEximImpl.java
@@ -102,7 +102,8 @@ public class JsonFullEximImpl implements CoalesceExim<JSONObject> {
                                                             "allowremove",
                                                             "count",
                                                             "hasactiverecords",
-                                                            "hasrecords");
+                                                            "hasrecords",
+                                                            "createdby");
 
     @Override
     public void importValues(JSONObject values, CoalesceEntity entity) throws CoalesceException

--- a/src/Coalesce/src/test/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceEntityTest.java
+++ b/src/Coalesce/src/test/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceEntityTest.java
@@ -2691,6 +2691,26 @@ public class CoalesceEntityTest {
 
         Assert.assertEquals(user1, entity.getCreatedBy());
         Assert.assertEquals(user3, entity.getModifiedBy());
+
+        entity.clearHistory();
+
+        Assert.assertEquals(user1, entity.getCreatedBy());
+        Assert.assertEquals(user3, entity.getModifiedBy());
+
+        entity = new TestEntity();
+        entity.initialize();
+        Assert.assertNull(entity.getCreatedBy());
+        Assert.assertEquals("", entity.getModifiedBy());
+
+        entity.createHistory(user2, "", 2);
+
+        Assert.assertNull(entity.getCreatedBy());
+        Assert.assertEquals(user2, entity.getModifiedBy());
+
+        entity.clearHistory();
+
+        Assert.assertNull(entity.getCreatedBy());
+        Assert.assertEquals(user2, entity.getModifiedBy());
     }
 
     // -----------------------------------------------------------------------//

--- a/src/Coalesce/src/test/java/com/incadencecorp/coalesce/framework/exim/impl/JsonFullEximImplTest.java
+++ b/src/Coalesce/src/test/java/com/incadencecorp/coalesce/framework/exim/impl/JsonFullEximImplTest.java
@@ -20,7 +20,15 @@ package com.incadencecorp.coalesce.framework.exim.impl;
 import com.incadencecorp.coalesce.api.Views;
 import com.incadencecorp.coalesce.common.helpers.EntityLinkHelper;
 import com.incadencecorp.coalesce.common.helpers.JodaDateTimeHelper;
-import com.incadencecorp.coalesce.framework.datamodel.*;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntity;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceEntityTemplate;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceFieldDefinition;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceRecordset;
+import com.incadencecorp.coalesce.framework.datamodel.CoalesceSection;
+import com.incadencecorp.coalesce.framework.datamodel.ECoalesceFieldDataTypes;
+import com.incadencecorp.coalesce.framework.datamodel.ELinkTypes;
+import com.incadencecorp.coalesce.framework.datamodel.TestEntity;
+import com.incadencecorp.coalesce.framework.datamodel.TestRecord;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Polygon;
 import com.vividsolutions.jts.util.GeometricShapeFactory;
@@ -28,6 +36,8 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Test;
+
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -81,6 +91,31 @@ public class JsonFullEximImplTest {
         Assert.assertEquals(record.getStringField().getBaseValue(), record2.getStringField().getBaseValue());
 
         Assert.assertEquals(record.getStringListField().getBaseValue(), record2.getStringListField().getBaseValue());
+    }
+
+    /**
+     * This test ensures that the creator does not make it back into the XML as an other attribute.
+     */
+    @Test
+    public void testCreator() throws Exception
+    {
+        String user = UUID.randomUUID().toString();
+
+        TestEntity entity = new TestEntity();
+        entity.initialize();
+        entity.setModifiedBy(user);
+
+        JsonFullEximImpl exim = new JsonFullEximImpl();
+        exim.setView(Views.Entity.class);
+
+        JSONObject result = exim.exportValues(entity, true);
+        Assert.assertEquals(user, result.getString("createdBy"));
+
+        CoalesceEntity imported = exim.importValues(result, CoalesceEntityTemplate.create(entity));
+
+        Assert.assertNull(imported.getAttribute("createdBy"));
+        Assert.assertNull(imported.getAttribute("createdby"));
+        Assert.assertEquals(user, imported.getCreatedBy());
     }
 
     /**


### PR DESCRIPTION
Included the created by and modified by as search parameters.

Updated the entity and linkage data controllers to populate the modified by field. 

Refactored Template and Entity data controllers to not go through the CRUD service but rather invoke the tasks directly for performance.

Updated the entity editor to display the creator and last modified fields.