### PR TITLE
Refactored StringEscapeUtils 

### DIFF
--- a/src/Coalesce.ExIm.XSD/src/main/java/com/incadencecorp/coalesce/exim/xsd/XSDEximImpl.java
+++ b/src/Coalesce.ExIm.XSD/src/main/java/com/incadencecorp/coalesce/exim/xsd/XSDEximImpl.java
@@ -23,7 +23,7 @@ import javax.xml.namespace.QName;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/src/Coalesce.Framework.Persistance/cosmos/persister/src/main/java/com/incadencecorp/coalesce/framework/persistance/cosmos/CosmosDocumentIterator.java
+++ b/src/Coalesce.Framework.Persistance/cosmos/persister/src/main/java/com/incadencecorp/coalesce/framework/persistance/cosmos/CosmosDocumentIterator.java
@@ -20,7 +20,7 @@ package com.incadencecorp.coalesce.framework.persistance.cosmos;
 
 import com.incadencecorp.coalesce.search.factory.CoalescePropertyFactory;
 import com.microsoft.azure.documentdb.Document;
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.geotools.geojson.geom.GeometryJSON;
 import org.json.JSONArray;

--- a/src/Coalesce.Framework.Persister.Elasticsearch/src/main/java/com/incadencecorp/coalesce/framework/persistance/elasticsearch/FeatureColumnIterator.java
+++ b/src/Coalesce.Framework.Persister.Elasticsearch/src/main/java/com/incadencecorp/coalesce/framework/persistance/elasticsearch/FeatureColumnIterator.java
@@ -1,8 +1,8 @@
 package com.incadencecorp.coalesce.framework.persistance.elasticsearch;
 
 import com.incadencecorp.coalesce.search.factory.CoalescePropertyFactory;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.geotools.feature.FeatureIterator;
 import org.opengis.feature.Feature;
 import org.opengis.filter.expression.PropertyName;

--- a/src/Coalesce/pom.xml
+++ b/src/Coalesce/pom.xml
@@ -177,6 +177,11 @@
             <artifactId>coalesce-classification</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.8</version>
+        </dependency>
 
         <!-- Required for the JSON annotations -->
         <dependency>

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/common/bitmask/SecurityBitmaskHashes.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/common/bitmask/SecurityBitmaskHashes.java
@@ -24,8 +24,8 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceFieldBase.java
+++ b/src/Coalesce/src/main/java/com/incadencecorp/coalesce/framework/datamodel/CoalesceFieldBase.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 
-import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 


### PR DESCRIPTION
Refactored to use org.apache.commons.text.StringEscapeUtils instead of lang3.StringEscapeUtils which has been deprecated.