### PR TITLE
Updated to ElasticGeo 2.16.1 

### DIFF
--- a/src/Coalesce.Bundles/bundle-geomesa/pom.xml
+++ b/src/Coalesce.Bundles/bundle-geomesa/pom.xml
@@ -71,6 +71,12 @@
  			<version>${accumulo.geomesa.version}</version>
  		</dependency>
  		-->
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+            <version>1.16.1</version>
+            <scope>provided</scope>
+        </dependency>
 
 	</dependencies>
 

--- a/src/Coalesce.Bundles/bundle-geotools/pom.xml
+++ b/src/Coalesce.Bundles/bundle-geotools/pom.xml
@@ -40,6 +40,7 @@
                         </Embed-Dependency>
                         <Embed-Transitive>true</Embed-Transitive>
                         <!-- 						<SPI-Consumer>java.util.ServiceLoader#load(java.lang.Class[org.geotools.data.DataStoreFactorySpi])</SPI-Consumer> -->
+                        <_noee>true</_noee>
                     </instructions>
                 </configuration>
 
@@ -101,9 +102,13 @@
             <artifactId>gt-metadata</artifactId>
             <version>${geotools.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.geotools</groupId>
+            <artifactId>gt-geojson</artifactId>
+            <version>${geotools.version}</version>
+        </dependency>
 
         <!-- Requires Java 1.9 -->
-        <!--
         <dependency>
             <groupId>org.geotools</groupId>
             <artifactId>gt-imagemosaic</artifactId>
@@ -119,13 +124,6 @@
             <artifactId>gt-process-feature</artifactId>
             <version>${geotools.version}</version>
         </dependency>
-        -->
-        <!-- INC version removes the Skunkwords class which is missing the packagename preventing the packages to be bundled into our bundle-geotool package for use within OSGi container using maven-bundle-plugin. -->
-        <dependency>
-            <groupId>org.geotools</groupId>
-            <artifactId>gt-geojson</artifactId>
-            <version>15-INC</version>
-        </dependency>
 
         <dependency>
             <artifactId>joda-time</artifactId>
@@ -133,5 +131,12 @@
             <version>${joda.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.locationtech.jts</groupId>
+            <artifactId>jts-core</artifactId>
+            <version>1.16.1</version>
+            <scope>provided</scope>
+        </dependency>
+
     </dependencies>
 </project>

--- a/src/Coalesce.Framework.Persistance/elasticsearch/pom.xml
+++ b/src/Coalesce.Framework.Persistance/elasticsearch/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <ironhide.version>2.0.4</ironhide.version>
         <elasticsearch.version>7.4.2</elasticsearch.version>
-        <elasticgeo.version>2.16.0-INC</elasticgeo.version>
+        <elasticgeo.version>2.16.1-INC</elasticgeo.version>
     </properties>
 
     <modules>

--- a/src/Coalesce.Framework.Persister.Elasticsearch/src/main/java/com/incadencecorp/coalesce/framework/persistance/elasticsearch/ElasticSearchPersistorSearch.java
+++ b/src/Coalesce.Framework.Persister.Elasticsearch/src/main/java/com/incadencecorp/coalesce/framework/persistance/elasticsearch/ElasticSearchPersistorSearch.java
@@ -105,18 +105,28 @@ public class ElasticSearchPersistorSearch extends ElasticSearchPersistor impleme
         try
         {
             DataStore datastore = getDataStore(index);
-            SimpleFeatureType feature = datastore.getSchema(index);
-
-            for (AttributeDescriptor attr : feature.getAttributeDescriptors())
+            try
             {
-                if (!attr.getLocalName().startsWith("_"))
-                {
-                    Object value = attr.getUserData().getOrDefault("analyzed", Boolean.FALSE);
+                SimpleFeatureType feature = datastore.getSchema(index);
 
-                    if (value instanceof Boolean && !((Boolean) value))
+                for (AttributeDescriptor attr : feature.getAttributeDescriptors())
+                {
+                    if (!attr.getLocalName().startsWith("_"))
                     {
-                        keywords.add(attr.getLocalName());
+                        Object value = attr.getUserData().getOrDefault("analyzed", Boolean.FALSE);
+
+                        if (value instanceof Boolean && !((Boolean) value))
+                        {
+                            keywords.add(attr.getLocalName());
+                        }
                     }
+                }
+            }
+            finally
+            {
+                if (!isDataStoreCacheEnabled())
+                {
+                    datastore.dispose();
                 }
             }
         }


### PR DESCRIPTION
Resolves an issue with threads not being released.

Added datastore disposal around the keyword query.